### PR TITLE
remove: drop lc.m1sk9.dev worker from Terraform management

### DIFF
--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -33,24 +33,3 @@ resource "cloudflare_workers_custom_domain" "ua" {
   hostname   = "ua.m1sk9.dev"
   service    = cloudflare_workers_script.ua.script_name
 }
-
-# lc.m1sk9.dev - LunaticChat VitePress documentation (assets deployed via CI/CD)
-resource "cloudflare_workers_script" "lc" {
-  account_id         = local.cloudflare_account_id
-  script_name        = "lunaticchat-docs"
-  content_file       = "${path.module}/workers/lc.js"
-  content_sha256     = filesha256("${path.module}/workers/lc.js")
-  main_module        = "lc.js"
-  compatibility_date = "2024-09-23"
-
-  lifecycle {
-    ignore_changes = [content, content_file, content_sha256, compatibility_date, compatibility_flags, bindings]
-  }
-}
-
-resource "cloudflare_workers_custom_domain" "lc" {
-  account_id = local.cloudflare_account_id
-  zone_id    = local.cloudflare_zone_id
-  hostname   = "lc.m1sk9.dev"
-  service    = cloudflare_workers_script.lc.script_name
-}

--- a/terraform/workers/lc.js
+++ b/terraform/workers/lc.js
@@ -1,5 +1,0 @@
-export default {
-  async fetch() {
-    return new Response("Deploying...");
-  },
-};


### PR DESCRIPTION
The lc.m1sk9.dev (lunaticchat-docs) Worker is now managed outside this repository. Resources have been removed from Terraform state to avoid interfering with external deployments.