### PR TITLE
feat(terraform): add Wallos with Cloudflare Tunnel and Access

### DIFF
--- a/terraform/cloudflare_access.tf
+++ b/terraform/cloudflare_access.tf
@@ -36,3 +36,32 @@ resource "cloudflare_zero_trust_access_application" "acrane" {
     precedence = 1
   }]
 }
+
+# Cloudflare Zero Trust Access for Wallos
+
+resource "cloudflare_zero_trust_access_policy" "wallos" {
+  account_id = local.cloudflare_account_id
+  name       = "Allow me@m1sk9.dev"
+  decision   = "allow"
+
+  include = [{
+    email = {
+      email = "me@m1sk9.dev"
+    }
+  }]
+}
+
+resource "cloudflare_zero_trust_access_application" "wallos" {
+  account_id       = local.cloudflare_account_id
+  name             = "Wallos"
+  domain           = "wallos.m1sk9.dev"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  allowed_idps = [cloudflare_zero_trust_access_identity_provider.github.id]
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.wallos.id
+    precedence = 1
+  }]
+}

--- a/terraform/cloudflare_tunnel.tf
+++ b/terraform/cloudflare_tunnel.tf
@@ -15,6 +15,10 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "s1" {
         service  = "http://localhost:3552"
       },
       {
+        hostname = "wallos.m1sk9.dev"
+        service  = "http://localhost:8282"
+      },
+      {
         service = "http_status:404"
       }
     ]
@@ -30,4 +34,15 @@ resource "cloudflare_dns_record" "acrane" {
   ttl     = 1
   proxied = true
   comment = "Cloudflare Tunnel - Arcane (s1)"
+}
+
+# DNS Record for Wallos (Subscription tracker)
+resource "cloudflare_dns_record" "wallos" {
+  zone_id = local.cloudflare_zone_id
+  name    = "wallos"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.s1.id}.cfargotunnel.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "Cloudflare Tunnel - Wallos (s1)"
 }


### PR DESCRIPTION
## Summary

- Expose Wallos (subscription tracker) on s1 at `https://wallos.m1sk9.dev` through the existing `s1` Cloudflare Tunnel (`localhost:8282`).
- Gate access via Cloudflare Zero Trust Access using the existing GitHub IdP and an allow-list policy for `me@m1sk9.dev`.

## Changes

| File | 内容 |
|------|------|
| `terraform/cloudflare_tunnel.tf` | `s1` ingress に `wallos.m1sk9.dev → http://localhost:8282` を追加，CNAME `wallos` を tunnel に向ける |
| `terraform/cloudflare_access.tf` | Wallos 用の Access Policy / Application を追加（GitHub IdP は既存リソースを再利用） |

## Plan

```
Plan: 3 to add, 1 to change, 0 to destroy.
```

- `+ cloudflare_dns_record.wallos`
- `+ cloudflare_zero_trust_access_policy.wallos`
- `+ cloudflare_zero_trust_access_application.wallos`
- `~ cloudflare_zero_trust_tunnel_cloudflared_config.s1` （ingress に wallos 追加）

## Test plan

- [ ] HCP Terraform 上で plan の差分確認
- [ ] apply 後 `https://wallos.m1sk9.dev` で GitHub 認証が走ることを確認
- [ ] s1 側で Wallos コンテナが `8282` で待ち受けていることを確認

Generated with Claude Code