### PR TITLE
feat(terraform): harden Cloudflare SSL/TLS settings

### DIFF
--- a/terraform/cloudflare_dns_record.tf
+++ b/terraform/cloudflare_dns_record.tf
@@ -9,7 +9,7 @@ resource "cloudflare_dns_record" "portfolio" {
   content = "m1sk9.github.io"
   type    = "CNAME"
   ttl     = 1
-  proxied = false
+  proxied = true
   comment = "portfolio"
 }
 
@@ -31,7 +31,7 @@ resource "cloudflare_dns_record" "lc_api_docs" {
   content = "m1sk9.github.io"
   type    = "CNAME"
   ttl     = 1
-  proxied = false
+  proxied = true
   comment = "LunaticChat API Docs"
 }
 

--- a/terraform/cloudflare_zone_setting.tf
+++ b/terraform/cloudflare_zone_setting.tf
@@ -1,0 +1,35 @@
+# Cloudflare Zone SSL/TLS settings.
+#
+# In provider v5 each zone setting is its own cloudflare_zone_setting resource
+# (the v4 cloudflare_zone_settings_override block no longer exists).
+
+# Edge-to-origin encryption mode.
+# "full" rather than "strict" so the edge keeps serving even if the GitHub Pages
+# certificate renewal stalls. Never "flexible" — it causes a redirect loop with
+# GitHub Pages.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "ssl"
+  value      = "full"
+}
+
+# Redirect every HTTP request to HTTPS at the edge.
+resource "cloudflare_zone_setting" "always_use_https" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "always_use_https"
+  value      = "on"
+}
+
+# Rewrite insecure http:// references to https:// in served content.
+resource "cloudflare_zone_setting" "automatic_https_rewrites" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "automatic_https_rewrites"
+  value      = "on"
+}
+
+# Reject TLS handshakes negotiated below TLS 1.2.
+resource "cloudflare_zone_setting" "min_tls_version" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}


### PR DESCRIPTION
## 目的

Security Insights の Moderate（Unproxied CNAME / no HSTS / missing TLS）のうち，proxy 化と SSL 設定で解消できる部分を片付ける．

HSTS は不可逆性が高いため **この PR には含めない**（証明書確認後に別 PR で対応）．

## 変更内容

- `terraform/cloudflare_dns_record.tf`: GitHub Pages 向け CNAME 2件を proxy 化
  - `portfolio` (m1sk9.dev): `proxied = false` → `true`
  - `lc_api_docs` (lc.api.m1sk9.dev): `proxied = false` → `true`
  - ※ 他のレコード（`babyrite_api_docs` 等）は変更なし
- `terraform/cloudflare_zone_setting.tf`: 新規作成．zone-level の SSL/TLS 設定を追加（provider v5.19.1 では設定ごとに `cloudflare_zone_setting` リソースを分割）
  - `ssl = "full"` … strict ではなく full．orange cloud 化後に GitHub の証明書更新が止まっても edge が生き続けるようにするため．**Flexible は redirect loop になるため絶対に使わない**
  - `always_use_https = "on"`
  - `automatic_https_rewrites = "on"`
  - `min_tls_version = "1.2"`

## ローカル確認

- `terraform fmt -recursive` ✅（変更なし）
- `tflint --chdir terraform/` ✅
- `terraform validate` ✅

## チェックリスト

- [ ] merge 前に GitHub Pages 側で証明書が発行済みで，grey のまま https://m1sk9.dev と https://lc.api.m1sk9.dev が通ることを確認
- [ ] GitHub Pages の "Enforce HTTPS" が有効
- [ ] CI の terraform plan が「proxied 2件の変更 + zone_setting 4件の追加」のみであること
- [ ] merge 後，両ドメインが HTTPS で表示されることを確認
- [ ] 問題なければ後続 PR で HSTS (security_header) を追加

Generated with Claude Code