### PR TITLE
feat(terraform): re-add Cloudflare zone SSL/TLS settings

### DIFF
--- a/terraform/cloudflare_zone_setting.tf
+++ b/terraform/cloudflare_zone_setting.tf
@@ -1,0 +1,35 @@
+# Cloudflare Zone SSL/TLS settings.
+#
+# In provider v5 each zone setting is its own cloudflare_zone_setting resource
+# (the v4 cloudflare_zone_settings_override block no longer exists).
+
+# Edge-to-origin encryption mode.
+# "full" rather than "strict" so the edge keeps serving even if the GitHub Pages
+# certificate renewal stalls. Never "flexible" — it causes a redirect loop with
+# GitHub Pages.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "ssl"
+  value      = "full"
+}
+
+# Redirect every HTTP request to HTTPS at the edge.
+resource "cloudflare_zone_setting" "always_use_https" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "always_use_https"
+  value      = "on"
+}
+
+# Rewrite insecure http:// references to https:// in served content.
+resource "cloudflare_zone_setting" "automatic_https_rewrites" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "automatic_https_rewrites"
+  value      = "on"
+}
+
+# Reject TLS handshakes negotiated below TLS 1.2.
+resource "cloudflare_zone_setting" "min_tls_version" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}


### PR DESCRIPTION
## 目的

#233 の止血で撤去した `cloudflare_zone_setting` 4件を再投入する．API token に **`Zone Settings:Edit`** 権限が付与されたため，#232 の apply を壊した 403 Forbidden が解消される見込み．

## 変更内容

`terraform/cloudflare_zone_setting.tf` を再作成（provider v5 では設定ごとに1リソース）:

- `ssl = "full"` … strict ではなく full（GitHub Pages の証明書更新が止まっても edge が生存）．**Flexible は redirect loop になるため不可**
- `always_use_https = "on"`
- `automatic_https_rewrites = "on"`
- `min_tls_version = "1.2"`

DNS レコードには触れない（lc.api は #233 で grey に戻したまま，m1sk9.dev は proxy 維持）．

## ローカル確認

- `terraform fmt -recursive` ✅
- `tflint --chdir terraform/` ✅
- `terraform validate` ✅

## チェックリスト

- [ ] CI の terraform plan が「`cloudflare_zone_setting` 4件の追加のみ（4 to add, 0 change, 0 destroy）」であること
- [ ] merge 後，CD apply が **success**（403 Forbidden が出ないこと＝権限付与の実証）
- [ ] apply 後，https://m1sk9.dev が引き続き HTTPS 200 で表示されること
- [ ] grey の lc.api / babyrite.api に影響が無いこと

## フォローアップ（このPRには含めない）

- [ ] 本PRの apply 安定後，HSTS（`security_header`）を別 PR で追加（`max-age` 短め開始 → 段階的に延長．`includeSubDomains` は grey の2階層サブドメインへの影響を確認してから）

Generated with Claude Code