### PR TITLE
feat(terraform): add HSTS (security_header) zone setting

### DIFF
--- a/terraform/cloudflare_zone_setting.tf
+++ b/terraform/cloudflare_zone_setting.tf
@@ -33,3 +33,25 @@ resource "cloudflare_zone_setting" "min_tls_version" {
   setting_id = "min_tls_version"
   value      = "1.2"
 }
+
+# HSTS (Strict-Transport-Security). Reversible-risk: browsers enforce HTTPS for
+# max_age seconds, so a certificate outage locks clients out. Introduced
+# conservatively and ramped up in later PRs:
+#   - max_age 1 day to keep the lock-in window short while we confirm behaviour
+#   - include_subdomains off so grey two-label subdomains (lc.api, babyrite.api)
+#     are not forced to HTTPS by the apex header
+#   - preload off (one-way once submitted)
+# nosniff (X-Content-Type-Options) shares this object but is out of scope here.
+resource "cloudflare_zone_setting" "security_header" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "security_header"
+  value = {
+    strict_transport_security = {
+      enabled            = true
+      include_subdomains = false
+      max_age            = 86400
+      nosniff            = false
+      preload            = false
+    }
+  }
+}


### PR DESCRIPTION
## 目的

#234 で SSL/TLS の土台（ssl=full / always_use_https / TLS1.2 / edge 証明書）が安定稼働したため，当初の方針どおり HSTS を別 PR で追加する．不可逆性が高い設定のため**保守的な初期値**で導入する．

## 変更内容

`cloudflare_zone_setting.tf` に `security_header`（HSTS）を追加:

```hcl
strict_transport_security = {
  enabled            = true
  include_subdomains = false   # apex のみ
  max_age            = 86400   # 1日
  nosniff            = false
  preload            = false
}
```

### 設計判断

- **max_age = 86400（1日）**: 締め出しの影響窓を短く保ち，挙動確認後に別 PR で 180日→1年へ段階的に延長
- **include_subdomains = false**: apex のみに HSTS．grey の2階層サブドメイン（lc.api / babyrite.api）をブラウザの HTTPS 強制に巻き込まない（将来証明書が切れても締め出されない）
- **preload = false**: 一度載せると解除困難なため見送り
- `nosniff`（X-Content-Type-Options）は HSTS とは別軸のため今回 off のまま

## ローカル確認

- `terraform fmt -recursive` ✅
- `tflint --chdir terraform/` ✅
- `terraform validate` ✅（value オブジェクト構造が provider v5.19.1 schema に適合）

## チェックリスト

- [ ] CI plan が `cloudflare_zone_setting.security_header` 1件の追加のみであること
- [ ] merge 後，CD apply が success
- [ ] apply 後，`curl -sI https://m1sk9.dev` のレスポンスに `strict-transport-security: max-age=86400` が付くこと
- [ ] `includeSubDomains` / `preload` が**付いていない**こと（apex のみ）
- [ ] grey の lc.api / babyrite.api のレスポンスに HSTS が付かないこと

## フォローアップ

- [ ] 数日安定したら別 PR で `max_age` を延長（180日→1年）
- [ ] 全サブドメインの HTTPS 安定を確認できたら `include_subdomains` / `preload` を検討

Generated with Claude Code