### PR TITLE
feat(terraform): disable workers.dev subdomain for all workers

### DIFF
--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -17,6 +17,14 @@ resource "cloudflare_workers_custom_domain" "blog" {
   service    = cloudflare_workers_script.blog.script_name
 }
 
+# Custom domain only — disable the workers.dev subdomain exposure.
+resource "cloudflare_workers_script_subdomain" "blog" {
+  account_id       = local.cloudflare_account_id
+  script_name      = cloudflare_workers_script.blog.script_name
+  enabled          = false
+  previews_enabled = false
+}
+
 # ua.m1sk9.dev - User-Agent echo service
 resource "cloudflare_workers_script" "ua" {
   account_id         = local.cloudflare_account_id
@@ -34,6 +42,14 @@ resource "cloudflare_workers_custom_domain" "ua" {
   service    = cloudflare_workers_script.ua.script_name
 }
 
+# Custom domain only — disable the workers.dev subdomain exposure.
+resource "cloudflare_workers_script_subdomain" "ua" {
+  account_id       = local.cloudflare_account_id
+  script_name      = cloudflare_workers_script.ua.script_name
+  enabled          = false
+  previews_enabled = false
+}
+
 # working.m1sk9.dev - Work hours calculator
 resource "cloudflare_workers_script" "working" {
   account_id         = local.cloudflare_account_id
@@ -49,4 +65,12 @@ resource "cloudflare_workers_custom_domain" "working" {
   zone_id    = local.cloudflare_zone_id
   hostname   = "working.m1sk9.dev"
   service    = cloudflare_workers_script.working.script_name
+}
+
+# Custom domain only — disable the workers.dev subdomain exposure.
+resource "cloudflare_workers_script_subdomain" "working" {
+  account_id       = local.cloudflare_account_id
+  script_name      = cloudflare_workers_script.working.script_name
+  enabled          = false
+  previews_enabled = false
 }


### PR DESCRIPTION
## 目的

Security Insights の `sk92en.workers.dev` 宛4件（Bot Fight Mode / Block AI bots / AI Labyrinth / security.txt）を，workers.dev 露出をなくすことでまとめて解消する．3つの Worker をカスタムドメイン経由のみに限定する．

## 変更内容

既存3スクリプトそれぞれに `cloudflare_workers_script_subdomain`（`enabled = false` / `previews_enabled = false`）を追加:

- `blog-redirect`（blog.m1sk9.dev）
- `ua-echo`（ua.m1sk9.dev）
- `work-hours`（working.m1sk9.dev）

既存の `cloudflare_workers_script` / `cloudflare_workers_custom_domain` は**変更しない**．

## ローカル確認

- `terraform fmt -recursive` ✅
- `tflint --chdir terraform/` ✅
- `terraform validate` ✅
- ローカル diff は3リソースの追加のみ（既存に変更なし）

## チェックリスト

- [ ] CI plan が「`cloudflare_workers_script_subdomain` 3件の追加のみ」であること（既存 `cloudflare_workers_script` / `cloudflare_workers_custom_domain` に diff が出ないこと）※ provider v5 の #6383 重複注記に留意
- [ ] merge 後，blog.m1sk9.dev / ua.m1sk9.dev / working.m1sk9.dev が引き続き応答すること
- [ ] `*.sk92en.workers.dev`（各 Worker の workers.dev URL）が到達不可になること

Generated with Claude Code