### PR TITLE
chore(ci): drop dorny/paths-filter to keep required checks reportable

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,27 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  changes:
-    runs-on: ubuntu-24.04
-    outputs:
-      terraform: ${{ steps.filter.outputs.terraform }}
-      ansible: ${{ steps.filter.outputs.ansible }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            terraform:
-              - 'terraform/**'
-              - '.github/workflows/cd.yaml'
-            ansible:
-              - 'ansible/**'
-              - '.github/workflows/cd.yaml'
-
   terraform-apply:
-    needs: changes
-    if: needs.changes.outputs.terraform == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -53,8 +33,6 @@ jobs:
         run: terraform apply -input=false -no-color -auto-approve -lock-timeout=10m
 
   ansible-deploy:
-    needs: changes
-    if: needs.changes.outputs.ansible == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,27 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  changes:
-    runs-on: ubuntu-24.04
-    outputs:
-      terraform: ${{ steps.filter.outputs.terraform }}
-      ansible: ${{ steps.filter.outputs.ansible }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            terraform:
-              - 'terraform/**'
-              - '.github/workflows/ci.yaml'
-            ansible:
-              - 'ansible/**'
-              - '.github/workflows/ci.yaml'
-
   terraform-plan:
-    needs: changes
-    if: needs.changes.outputs.terraform == 'true'
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -58,8 +38,6 @@ jobs:
         run: terraform plan -input=false -lock-timeout=10m
 
   ansible-plan:
-    needs: changes
-    if: needs.changes.outputs.ansible == 'true'
     runs-on: ubuntu-24.04
     defaults:
       run:


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v3` を使った `changes` job を CI / CD 両方から削除
- `terraform-plan` / `ansible-plan` / `terraform-apply` / `ansible-deploy` を常時実行に変更

## Why

- `terraform-plan` / `ansible-plan` がブランチ保護で Required check になっているが，paths-filter で skip されると Required check が報告されず PR が merge 不能になる（PR #243 は admin override が必要だった）
- `dorny/paths-filter@v3` は Node.js 20 deprecation 警告も出ていた

## Trade-off

- 関連しない変更でも plan/apply が走るが，terraform は no-op，ansible は冪等なので副作用なし
- 実行時間は数十秒〜1 分程度の増加

## Test plan

- [ ] この PR の CI で `terraform-plan` / `ansible-plan` が両方走り success すること
- [ ] merge 後の CD で `terraform-apply` / `ansible-deploy` が両方走り success すること

Generated with Claude Code