### PR TITLE
chore(ci): bump jdx/mise-action from v3 to v4

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Development Environment
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
 
       - name: Terraform Init
         run: terraform init
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Development Environment
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
 
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Development Environment
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
 
       - name: Terraform Format
         run: terraform fmt -check -recursive
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Development Environment
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
 
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yaml` / `.github/workflows/cd.yaml` の `jdx/mise-action@v3` を `@v4` に更新

## Why

- v3 は Node.js 20 で動作し，GitHub Actions が 2026-06-16 から強制的に Node.js 24 へ移行させるため deprecation 警告が出ていた
- v4.x は Node.js 24 対応．現状の最新は v4.1.0（2026-06-04）

## Test plan

- [ ] この PR の CI で `terraform-plan` / `ansible-plan` が success すること
- [ ] merge 後の CD で `terraform-apply` / `ansible-deploy` が success すること
- [ ] Node.js 20 deprecation 警告（mise-action）が消えること

Generated with Claude Code