### PR TITLE
chore(ci): serialize CD runs with concurrency group

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: cd-main
+  cancel-in-progress: false
+
 jobs:
   terraform-apply:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- `.github/workflows/cd.yaml` に `concurrency: { group: cd-main, cancel-in-progress: false }` を追加し，main への近接 push を直列実行に強制

## Why

PR #244 で paths-filter を撤廃したため，全 merge で `ansible-deploy` が走る．近接 merge（Renovate バッチ等）が並列実行されると Tailscale SSH が衝突し，片方が UNREACHABLE (exit code 4) で失敗する事象を観測した（PR #245 merge 時に #242 と同時実行→両方失敗→rerun で復旧）．

`concurrency:` で同一 group の run を直列化することで s1 への SSH 競合を回避する．`cancel-in-progress: false` により進行中の deploy は kill されず，後発は queue で待機する．

## Note

GitHub Actions の `concurrency:` は標準機能で，Merge Queue とは別物．個人 repo でも利用可．

## Test plan

- [ ] この PR の CI で `terraform-plan` / `ansible-plan` が success すること
- [ ] merge 後の CD が success すること
- [ ] 次の Renovate バッチ等で近接 merge が発生した際，CD が直列実行され全て success すること

Generated with Claude Code