### PR TITLE
fix(ansible): make chime sanity check defensive against missing container key

### DIFF
--- a/ansible/playbooks/services.yml
+++ b/ansible/playbooks/services.yml
@@ -52,8 +52,11 @@
       community.docker.docker_container_info:
         name: chime-app-1
       register: chime_info
-      until: chime_info.container.State.Status == "running"
-      retries: 6
+      until:
+        - chime_info.container is defined
+        - chime_info.container is not none
+        - chime_info.container.State.Status | default('') == "running"
+      retries: 12
       delay: 5
       when: not ansible_check_mode
 
@@ -73,4 +76,6 @@
         msg: "chime container restarted during settle window (restart_count={{ chime_info_after.container.RestartCount }})"
       when:
         - not ansible_check_mode
-        - chime_info_after.container.RestartCount | int > 0
+        - chime_info_after.container is defined
+        - chime_info_after.container is not none
+        - chime_info_after.container.RestartCount | default(0) | int > 0


### PR DESCRIPTION
## Summary

PR #248 deployed chime successfully (running on s1, all 6 reminders loaded), but the post-deploy `Verify chime container reached running state` task failed with `object of type 'dict' has no attribute 'container'`. `community.docker.docker_container_info` returns a registered dict whose `container` key is absent (not None) on the very first poll right after `docker compose up`, and the until expression dereferenced it without a guard.

- Guard the `until` expression with `is defined` / `is not none` checks and fall back through `default('')`.
- Apply the same guard to the post-settle `RestartCount` comparison.
- Raise `retries` 6 → 12 to give the first poll more headroom on cold pulls.

## Test plan

- [ ] `ansible-plan` is green.
- [ ] After merge, `cd.yaml` completes successfully. This time the `Verify chime container reached running state` and follow-up sanity check tasks should pass (chime is already running).

Generated with Claude Code