### PR TITLE
chore(chime): bump to v0.2.0 and add healthcheck

### DIFF
--- a/ansible/roles/docker_compose_app/files/chime/compose.yaml
+++ b/ansible/roles/docker_compose_app/files/chime/compose.yaml
@@ -1,7 +1,7 @@
 name: chime
 services:
   app:
-    image: ghcr.io/m1sk9/chime:v0.1.0
+    image: ghcr.io/m1sk9/chime:v0.2.0
     environment:
       CHIME_CONFIG: /etc/chime/config.toml
     volumes:
@@ -9,3 +9,9 @@ services:
     env_file:
       - .env
     restart: always
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/chime", "health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3


### PR DESCRIPTION
## Summary

- chime image を `v0.1.0` → `v0.2.0` にアップデート
- compose.yaml に `healthcheck` を追加

## Details

chime の health check は heartbeat ファイル方式で，`chime health` が `CHIME_CONFIG` から `tick_interval_sec` を読んで鮮度を判定します（しきい値 `2 * tick_interval_sec`）．現在の `tick_interval_sec = 30` に対し `interval: 30s` で問題ありません．

README の Docker 実装例に準拠しています:
https://github.com/m1sk9/chime/blob/main/README.md#health-check

```yaml
healthcheck:
  test: ["CMD", "/usr/local/bin/chime", "health"]
  interval: 30s
  timeout: 5s
  start_period: 10s
  retries: 3
```

Generated with Claude Code