### PR TITLE
feat(terraform): add cookieless Cloudflare Web Analytics for portfolio

### DIFF
--- a/terraform/cloudflare_web_analytics.tf
+++ b/terraform/cloudflare_web_analytics.tf
@@ -1,0 +1,17 @@
+# Cloudflare Web Analytics for the portfolio (m1sk9.dev).
+#
+# Privacy-friendly, cookieless analytics. The portfolio zone is orange-clouded
+# (see cloudflare_dns_record.portfolio, proxied = true), so auto_install lets the
+# edge inject the analytics beacon automatically — no change is needed in the
+# Zola site itself.
+#
+# Requires the API token to carry Account Settings Read + Write.
+resource "cloudflare_web_analytics_site" "portfolio" {
+  account_id   = local.cloudflare_account_id
+  zone_tag     = local.cloudflare_zone_id
+  auto_install = true
+
+  # Collect Real User Monitoring (Core Web Vitals: LCP, CLS, ...) on top of the
+  # basic page-view metrics. Requires auto_install = true.
+  enabled = true
+}


### PR DESCRIPTION
## 概要

m1sk9.dev (portfolio zone) に cookieless な Cloudflare Web Analytics を導入する．RUM (Core Web Vitals: LCP / CLS など) も収集する．

## 詳細

- portfolio zone は orange-cloud (`cloudflare_dns_record.portfolio`, `proxied = true`) なので `auto_install = true` でエッジがビーコンを自動注入する．サイト側 (Zola / GitHub Pages) の変更は不要．
- `enabled = true` で RUM を有効化．

Generated by Claude Code