### PR TITLE
Show end time based on 13:00 start in working hours calculator

### DIFF
--- a/terraform/workers/working.js
+++ b/terraform/workers/working.js
@@ -14,12 +14,14 @@ const HTML = `<!DOCTYPE html>
   <textarea id="input" spellcheck="false" rows="12" cols="40" placeholder="13:00-15:00"></textarea>
   <div id="total"></div>
   <div id="min"></div>
+  <div id="from13"></div>
   <table id="rows"></table>
 
 <script>
   const input = document.getElementById('input');
   const totalEl = document.getElementById('total');
   const minEl = document.getElementById('min');
+  const from13El = document.getElementById('from13');
   const rowsEl = document.getElementById('rows');
 
   function normalize(s) {
@@ -43,6 +45,14 @@ const HTML = `<!DOCTYPE html>
     if (m===0) return h+'時間';
     return h+'時間'+m+'分';
   }
+  function clock(mins) {
+    const base = 13*60 + mins;
+    const days = Math.floor(base / (24*60));
+    const t = base % (24*60);
+    const h = Math.floor(t/60), m = t%60;
+    const hhmm = String(h).padStart(2,'0')+':'+String(m).padStart(2,'0');
+    return days>0 ? hhmm+'（+'+days+'日）' : hhmm;
+  }
   function esc(s){return s.replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));}
   function render() {
     let total=0, valid=0, rows='';
@@ -53,8 +63,12 @@ const HTML = `<!DOCTYPE html>
       total += r.minutes; valid++;
       rows += '<tr><td>'+esc(r.range)+'</td><td>'+fmt(r.minutes)+'</td></tr>';
     }
-    if (valid===0) { totalEl.textContent='—'; minEl.textContent=''; }
-    else { totalEl.textContent=fmt(total); minEl.textContent='= '+total+' 分（'+valid+' 区間）'; }
+    if (valid===0) { totalEl.textContent='—'; minEl.textContent=''; from13El.textContent=''; }
+    else {
+      totalEl.textContent=fmt(total);
+      minEl.textContent='= '+total+' 分（'+valid+' 区間）';
+      from13El.textContent='13:00 + '+fmt(total)+' = '+clock(total);
+    }
     rowsEl.innerHTML = rows;
   }
   input.addEventListener('input', render);


### PR DESCRIPTION
## 概要

稼働時間カリキュレーター（`terraform/workers/working.js`）に，総稼働時間を `13:00` 起点で足した終了時刻を表示する機能を追加しました．

## 変更点

- `clock(mins)` を追加: `13:00`（780分）に総稼働分を加算し `HH:MM` 形式で返す．24時間を超える場合は `（+N日）` を付記
- `#from13` 要素を追加し，`13:00 + <総稼働時間> = <終了時刻>` を表示

## 表示例

- 合計 8時間 → `13:00 + 8時間 = 21:00`
- 合計 12時間 → `13:00 + 12時間 = 01:00（+1日）`

## 確認

ローカルで `fetch()` が返す HTML を生成し，ブラウザで挙動を確認済み．

Generated by Claude Code