### PR TITLE
fix(ansible): recreate container when bind-mounted config files change

### DIFF
--- a/ansible/roles/docker_compose_app/tasks/main.yml
+++ b/ansible/roles/docker_compose_app/tasks/main.yml
@@ -19,6 +19,7 @@
     src: "{{ app_name }}/compose.yaml"
     dest: "{{ app_dir }}/compose.yaml"
     mode: "0644"
+  register: compose_file
   check_mode: false
 
 - name: "{{ app_name }} | Deploy service files (env, config)"
@@ -27,12 +28,18 @@
     dest: "{{ item.dest }}"
     mode: "{{ item.mode | default('0600') }}"
   loop: "{{ app_files }}"
+  register: service_files
   no_log: true
 
+# Bind-mounted config files (e.g. config.toml) are read once at container
+# startup. `docker_compose_v2` only recreates on service-definition changes,
+# so a content-only change would otherwise never take effect. Force a
+# recreate whenever a deployed file changed; otherwise leave it to `auto`.
 - name: "{{ app_name }} | Start stack"
   community.docker.docker_compose_v2:
     project_src: "{{ app_dir }}"
     state: present
     remove_orphans: true
+    recreate: "{{ 'always' if ((compose_file.changed | default(false)) or (service_files.changed | default(false))) else 'auto' }}"
   register: compose_up
   when: not ansible_check_mode


### PR DESCRIPTION
## 概要

bind mount した設定ファイル（`config.toml` など）の内容変更が，コンテナに反映されない問題を修正する．

## 背景

`docker_compose_app` role の "Start stack" は `community.docker.docker_compose_v2` を `state: present` で実行している．これは **compose.yaml やイメージといったサービス定義が変わった時だけ**コンテナを再作成する．bind mount したファイルの**内容だけ**が変わってもサービス定義は変化しないため，コンテナは再作成されず，起動時に読み込んだ設定のまま動き続ける．

これが #274 の根本原因：babyrite に `[log] format = "json"` を入れた config.toml をデプロイしても，コンテナが再作成されず JSON ログに切り替わらなかった（CD で ansible 自体は走っていたが docker compose が「定義に変化なし」と判断していた）．

## 変更内容

- compose / config ファイルの copy タスクを `register` する
- いずれかが変更された場合のみ `recreate: always` を指定し，変更がなければ `auto`（従来挙動）にフォールバック

これにより，設定ファイル単独の変更でもコンテナが再作成されて反映される．変更がない通常デプロイでは余計な再作成（churn）は発生しない．

## テスト

- `ansible-playbook --syntax-check playbooks/services.yml` 通過

## 補足

この PR をマージしても，既に stale な babyrite コンテナは config.toml に差分がないため自動再作成されない．JSON ログを今すぐ有効化するには，一度だけ手動で強制再作成が必要：

```
ssh m1sk9@dev-m1sk9-s1 'cd ~/services/babyrite; docker compose up -d --force-recreate'
```

Closes #274

Generated by Claude Code