### PR TITLE
feat(terraform): add honeypot.api DNS record for GitHub Pages

### DIFF
--- a/terraform/cloudflare_dns_record.tf
+++ b/terraform/cloudflare_dns_record.tf
@@ -35,6 +35,17 @@ resource "cloudflare_dns_record" "lc_api_docs" {
   comment = "LunaticChat API Docs"
 }
 
+# HoneyPot (GitHub Pages)
+resource "cloudflare_dns_record" "honeypot_api" {
+  zone_id = local.cloudflare_zone_id
+  name    = "honeypot.api"
+  content = "m1sk9.github.io"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+  comment = "HoneyPot"
+}
+
 # Proton Mail DKIM
 resource "cloudflare_dns_record" "protonmail_dkim1" {
   zone_id = local.cloudflare_zone_id


### PR DESCRIPTION
## Summary

Add a Cloudflare DNS record to host `https://m1sk9.github.io/HoneyPot/` at `https://honeypot.api.m1sk9.dev/`.

- `honeypot.api` CNAME → `m1sk9.github.io`, `proxied = false`
- Follows the existing pattern of `babyrite.api` / `lc.api` (2-label subdomains are not covered by Universal SSL, so proxy is kept off to avoid breaking HTTPS)

## Follow-up (outside this repo)

After this is merged and DNS propagates, set the custom domain on the HoneyPot repository's GitHub Pages to `honeypot.api.m1sk9.dev` so GitHub issues the HTTPS certificate.

Generated with Claude Code