### PR TITLE
fix(tailscale): drop invalid "user:" prefix from individual user targets

### DIFF
--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -57,11 +57,11 @@
     // ===== Node Attributes (Funnel / NextDNS / Taildrive) =====
     "nodeAttrs": [
         {
-            "target": ["user:m1sk9@github", "tag:server-s1"],
+            "target": ["m1sk9@github", "tag:server-s1"],
             "attr":   ["nextdns:${NEXTDNS_PROFILE_ID}"],
         },
         {
-            "target": ["user:m1sk9@github", "tag:server-s1"],
+            "target": ["m1sk9@github", "tag:server-s1"],
             "attr":   ["drive:share", "drive:access"],
         },
         {


### PR DESCRIPTION
## Summary
- `"user:m1sk9@github"` is not a valid selector for an individual user — that prefix is only for domain wildcards (`user:*@example.com`). It silently matched nothing.
- This meant the `nextdns:${NEXTDNS_PROFILE_ID}` and `drive:share`/`drive:access` nodeAttrs never actually applied to m1sk9's own devices (confirmed via `tailscale debug netmap` showing neither capability on a Mac after ACL apply + full reconnect).
- Fixes both occurrences to the bare form `"m1sk9@github"`.

## Test plan
- [ ] CI: tailscale-acl-test green
- [ ] After merge: `tailscale debug netmap` on a personal device shows the Taildrive/nextdns nodeAttrs applied, and Taildrive access to s1's `pdfding_consume` share works