### PR TITLE
chore(backup): add pdfding db/media to restic backup targets

### DIFF
--- a/ansible/inventory/group_vars/all/vars.yml
+++ b/ansible/inventory/group_vars/all/vars.yml
@@ -20,3 +20,8 @@ backup_targets:
       - /home/m1sk9/wallos-data/db/wallos.db
     paths:
       - /home/m1sk9/wallos-data/logos
+  - name: pdfding
+    sqlite_dbs:
+      - /home/m1sk9/pdfding-data/db/db.sqlite3
+    paths:
+      - /home/m1sk9/pdfding-data/media


### PR DESCRIPTION
## Summary
- Adds `pdfding` to `backup_targets`: sqlite db (online-snapshotted) + media dir.
- `consume/` is deliberately not backed up — it's a transient drop folder, PdfDing empties it on every ingest cycle.

## Test plan
- [ ] CI: ansible-plan green
- [ ] Next Friday 03:00 backup run includes a `pdfding`-tagged restic snapshot