### PR TITLE
fix(cloudflare): serve m1sk9.dev from Cloudflare Workers instead of GitHub Pages

### DIFF
--- a/terraform/cloudflare_dns_record.tf
+++ b/terraform/cloudflare_dns_record.tf
@@ -2,16 +2,9 @@
 
 # --- CNAME Records ---
 
-# Portfolio (GitHub Pages)
-resource "cloudflare_dns_record" "portfolio" {
-  zone_id = local.cloudflare_zone_id
-  name    = "m1sk9.dev"
-  content = "m1sk9.github.io"
-  type    = "CNAME"
-  ttl     = 1
-  proxied = true
-  comment = "portfolio"
-}
+# The apex record for the portfolio is not declared here: it is created and owned
+# by cloudflare_workers_custom_domain.portfolio. Declaring it in both places would
+# make the two resources fight over the same record on every apply.
 
 # babyrite API Documentation (GitHub Pages)
 resource "cloudflare_dns_record" "babyrite_api_docs" {

--- a/terraform/cloudflare_dns_record.tf
+++ b/terraform/cloudflare_dns_record.tf
@@ -2,9 +2,26 @@
 
 # --- CNAME Records ---
 
-# The apex record for the portfolio is not declared here: it is created and owned
-# by cloudflare_workers_custom_domain.portfolio. Declaring it in both places would
-# make the two resources fight over the same record on every apply.
+# Portfolio (rollback target — the portfolio itself is served by Workers)
+#
+# Why keep a record that nothing resolves to in practice: the apex is claimed by
+# cloudflare_workers_route.portfolio, so requests are answered by the Worker and
+# GitHub Pages is never fetched. This record stays as the rollback path — delete
+# the route and the apex falls straight back to Pages with no DNS change. It is
+# also what the route attaches to: the route needs a proxied record on the
+# hostname to sit in front of.
+#
+# Note that the Pages certificate for this origin is expired, so it is only a
+# usable fallback while the zone runs SSL/TLS mode Full (non-strict).
+resource "cloudflare_dns_record" "portfolio" {
+  zone_id = local.cloudflare_zone_id
+  name    = "m1sk9.dev"
+  content = "m1sk9.github.io"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "portfolio"
+}
 
 # babyrite API Documentation (GitHub Pages)
 resource "cloudflare_dns_record" "babyrite_api_docs" {

--- a/terraform/cloudflare_web_analytics.tf
+++ b/terraform/cloudflare_web_analytics.tf
@@ -1,9 +1,14 @@
 # Cloudflare Web Analytics for the portfolio (m1sk9.dev).
 #
-# Privacy-friendly, cookieless analytics. The portfolio zone is orange-clouded
-# (see cloudflare_dns_record.portfolio, proxied = true), so auto_install lets the
-# edge inject the analytics beacon automatically — no change is needed in the
-# Zola site itself.
+# Privacy-friendly, cookieless analytics. The portfolio is served through the
+# Cloudflare edge (see cloudflare_workers_custom_domain.portfolio, which serves
+# the Zola build from Workers static assets), so auto_install lets the edge inject
+# the analytics beacon automatically — no change is needed in the Zola site itself.
+#
+# Why not inject the beacon from the Zola template instead: keeping it at the edge
+# means the token lives only in Terraform. If edge injection turns out not to apply
+# to Worker-generated responses, switch to auto_install = false and inject in the
+# template — never both, or page views are counted twice.
 #
 # Requires the API token to carry Account Settings Read + Write.
 resource "cloudflare_web_analytics_site" "portfolio" {

--- a/terraform/cloudflare_web_analytics.tf
+++ b/terraform/cloudflare_web_analytics.tf
@@ -1,9 +1,10 @@
 # Cloudflare Web Analytics for the portfolio (m1sk9.dev).
 #
-# Privacy-friendly, cookieless analytics. The portfolio is served through the
-# Cloudflare edge (see cloudflare_workers_custom_domain.portfolio, which serves
-# the Zola build from Workers static assets), so auto_install lets the edge inject
-# the analytics beacon automatically — no change is needed in the Zola site itself.
+# Privacy-friendly, cookieless analytics. The apex stays proxied, but the response
+# now comes from a Worker serving the Zola build as static assets rather than from
+# GitHub Pages (see cloudflare_workers_route.portfolio), so auto_install lets the
+# edge inject the analytics beacon automatically — no change is needed in the Zola
+# site itself.
 #
 # Why not inject the beacon from the Zola template instead: keeping it at the edge
 # means the token lives only in Terraform. If edge injection turns out not to apply

--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -1,5 +1,23 @@
 # Cloudflare Workers
 
+# m1sk9.dev - Portfolio (Zola static site served by Workers static assets)
+#
+# Why not a cloudflare_workers_script resource like the others below: the script
+# and its assets are a per-commit Zola build artifact, deployed by wrangler from
+# the m1sk9.dev repository. Terraform cannot own content it does not build, so
+# `service` is a plain string literal instead of a resource reference and the
+# ownership boundary is: wrangler owns the script, Terraform owns the hostname.
+#
+# Why not a cloudflare_workers_script_subdomain resource: wrangler touches the
+# workers.dev subdomain on every deploy, so Terraform would fight it on each
+# run. The exposure is disabled on the wrangler side (`workers_dev = false`).
+resource "cloudflare_workers_custom_domain" "portfolio" {
+  account_id = local.cloudflare_account_id
+  zone_id    = local.cloudflare_zone_id
+  hostname   = "m1sk9.dev"
+  service    = "m1sk9-dev"
+}
+
 # blog.m1sk9.dev - Redirect to m1sk9.dev/posts/ with Mastodon rel="me"
 resource "cloudflare_workers_script" "blog" {
   account_id         = local.cloudflare_account_id

--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -5,17 +5,23 @@
 # Why not a cloudflare_workers_script resource like the others below: the script
 # and its assets are a per-commit Zola build artifact, deployed by wrangler from
 # the m1sk9.dev repository. Terraform cannot own content it does not build, so
-# `service` is a plain string literal instead of a resource reference and the
-# ownership boundary is: wrangler owns the script, Terraform owns the hostname.
+# `script` is a plain string literal instead of a resource reference and the
+# ownership boundary is: wrangler owns the script, Terraform owns the routing.
+#
+# Why not a cloudflare_workers_custom_domain: a custom domain owns the hostname's
+# DNS record itself, so adopting it would mean destroying and recreating the apex
+# record — a downtime window on the way in, and a record to rebuild on the way
+# out. A route attaches to the existing proxied record instead: the cutover and
+# the rollback are a single route being added or removed, with the CNAME left
+# untouched (see cloudflare_dns_record.portfolio).
 #
 # Why not a cloudflare_workers_script_subdomain resource: wrangler touches the
 # workers.dev subdomain on every deploy, so Terraform would fight it on each
 # run. The exposure is disabled on the wrangler side (`workers_dev = false`).
-resource "cloudflare_workers_custom_domain" "portfolio" {
-  account_id = local.cloudflare_account_id
-  zone_id    = local.cloudflare_zone_id
-  hostname   = "m1sk9.dev"
-  service    = "m1sk9-dev"
+resource "cloudflare_workers_route" "portfolio" {
+  zone_id = local.cloudflare_zone_id
+  pattern = "m1sk9.dev/*"
+  script  = "m1sk9-dev"
 }
 
 # blog.m1sk9.dev - Redirect to m1sk9.dev/posts/ with Mastodon rel="me"


### PR DESCRIPTION
## 背景

`m1sk9.dev` の apex は `cloudflare_dns_record.portfolio` (`CNAME → m1sk9.github.io`, `proxied = true`) で GitHub Pages を向いていますが，この構成は構造的に証明書を維持できません．

- GitHub Pages 側の Let's Encrypt 証明書が **2026-07-27 00:08:48 GMT に失効済み**．GitHub Pages API の `https_certificate.state` は `bad_authz`（"The ACME authorization is in a bad state. We need to start over."）．
- 原因は apex が orange-cloud であるため Let's Encrypt の HTTP-01 検証が GitHub Pages の origin に直接到達できないこと．CAA レコードは存在せず DNSSEC も正常で，実測でこの 2 つは原因から除外済み．
- したがって **証明書を手で復旧しても 90 日ごとに同じ理由で失敗します**．一時的な障害ではありません．

現状 site が 200 を返しているのは，zone の SSL/TLS モードが **Full (strict ではない)** だからです．

- Cloudflare↔origin 間は暗号化されているだけで，**origin 証明書の検証がされていない**（失効した証明書をそのまま受け入れている）．
- さらに GitHub Pages の origin は平文 HTTP も受けるため，`Host: m1sk9.dev` を付けて GitHub の IP を直接叩くと **TLS なしでサイト全文が取得できる**（実測済み）．

**origin を Cloudflare 自身にする**ことで ACME の検証経路の問題が消えます．Worker が応答するあいだ origin へのフェッチは発生しないため，失効した Pages 証明書は経路から外れます．

## 変更内容

所有権を分けて，両者が同じリソースを取り合わないようにしています．

| 対象 | 所有者 |
| --- | --- |
| Worker script 本体 + assets (Zola の `build/`) | wrangler (m1sk9.dev repo の GitHub Actions)．script 名は `m1sk9-dev` |
| routing | Terraform (このリポジトリ) |

1. `cloudflare_workers_route.portfolio` を追加（`pattern = "m1sk9.dev/*"`, `script = "m1sk9-dev"`）．
   - `cloudflare_workers_script` は**作りません**．script はコミットごとに変わるビルド成果物で Terraform が内容を所有できないため，`script` は既存の blog / ua / working のようなリソース参照ではなく文字列リテラルになります．
   - `cloudflare_workers_custom_domain` ではなく **route** を選びました．custom domain は hostname の DNS レコード自体を所有するため，apex を渡すには既存レコードの destroy と再作成が必要で，切替時にダウンタイムが，切り戻し時にはレコードの再構築が発生します．route は既存の proxied レコードに貼り付くだけなので，**切替は route 1 個の追加，ロールバックは route 1 個の削除**で済みます．
   - `cloudflare_workers_script_subdomain` も**作りません**．wrangler が deploy ごとに workers.dev subdomain を触るため，Terraform に持たせると毎回取り合いになります．無効化は wrangler 側 (`workers_dev = false`) で行います．
   - 以上の Why not はすべてコードコメントに残しています．
2. `cloudflare_dns_record.portfolio` は**削除せず維持**します．route があるあいだこの CNAME 先へのフェッチは起きませんが，(a) route が貼り付く先の proxied レコードとして必要で，(b) 切り戻し先そのものだからです．コメントを「live origin」から「rollback target」に更新しています．
3. `cloudflare_web_analytics.tf` は `auto_install = true` のまま**機能変更なし**．zone が proxied のままで origin だけ Workers になった旨にコメントを更新しています．

## apply とロールバック

**このリポジトリの CD は main への push で `terraform apply` が自動実行されます**．つまり merge がそのまま本番の切替になります．

- **単一 apply で完結し，無停止で切替わります．** DNS レコードの destroy / create が起きないため，propagation の待ちも不定状態もありません．plan は `1 to add, 0 to change, 0 to destroy`．
- **前提条件は満たされています．** Worker `m1sk9-dev` は m1sk9.dev repo 側で deploy 済み（PR #31, #32 merge 済み，assets 87 件，`/.well-known/security.txt` を含む，`not_found_handling: "404-page"` 設定済み）．
- **ロールバックは `cloudflare_workers_route.portfolio` の削除のみ**です．route が消えた時点で apex は即座に GitHub Pages 配信へ戻ります（レコードは触っていないので DNS 変更は不要）．ただし戻り先の Pages 証明書は失効しているため，SSL/TLS モードが Full (non-strict) であることに依存した暫定的な退避先です．

> 以前の版の本文にあった `terraform apply -target` で destroy を先に通す手順は**撤回しました**．`apply` は CI 専用（`TF_TOKEN_APP_TERRAFORM_IO` は GitHub secrets のみ）で，ローカルから先行して targeted apply を打つ手段がないため実行不能でした．route 方式ではそもそも destroy が発生しないので手順自体が不要です．

## 切替後の検証項目

エッジでの HTML 書き換えが Worker のレスポンスにも適用されるかを公式ドキュメントで確認できませんでした．**切替直後に実測が必要です．**

1. **Web Analytics の beacon 注入** — 素の curl では注入されない（リクエストの見た目で条件分岐している）ので，ブラウザ相当の User-Agent と `Accept: text/html,...` を付けて `https://m1sk9.dev/` を取得し，`static.cloudflareinsights.com/beacon.min.js` と token `ad62363fe24b4c41a6ce65b6920625f8` が含まれることを確認する．現行の GitHub Pages 構成では注入されていることを実測済み．
   - **効かない場合のフォールバック**: `auto_install = false` にして，Zola のテンプレート側で beacon を手動注入する．二重計測を避けるため，必ずどちらか片方だけにする．
2. **Email Obfuscation** — 同じレスポンスに `/cdn-cgi/scripts/.../email-decode.min.js` が含まれること．現行構成では注入されていることを実測済み．
3. **security.txt** — `https://m1sk9.dev/.well-known/security.txt` が 200 で返り，`gpg --verify` が通ること（RFC 9116．パスは変更できない）．
4. **サイト本体** — `https://m1sk9.dev/` が 200 で，最新のビルド内容であること．

切替後は apex の origin が Cloudflare 自身になるため上記の平文経路は消えますが，SSL/TLS モードは他の proxied な origin にも効く zone 単位の設定です．別 PR で strict 化を検討する価値があります（このリポジトリの `cloudflare_zone_setting.tf` の範囲）．

## 検証結果

- `terraform fmt -check -diff` — 差分なし
- `terraform validate` — Success
- `tflint` — issue なし
- `terraform plan` — `Plan: 1 to add, 0 to change, 0 to destroy`（`cloudflare_workers_route.portfolio` の create のみ．DNS レコードと Web Analytics は変更なし）

`terraform apply` はこの PR の作業では**一切実行していません**．

---

Generated by Claude Code
