### PR TITLE
feat(cloudflare): add DNS record for the Better Stack status page

### DIFF
--- a/terraform/cloudflare_dns_record.tf
+++ b/terraform/cloudflare_dns_record.tf
@@ -56,6 +56,23 @@ resource "cloudflare_dns_record" "honeypot_api" {
   comment = "HoneyPot"
 }
 
+# Better Stack status page (status.m1sk9.dev)
+#
+# Why proxied = false: Better Stack terminates TLS on statuspage.betteruptime.com
+# and issues its own certificate for this hostname, so the record has to stay
+# DNS-only — proxying it would break HTTPS. This is a 1-level subdomain, so the
+# 2-level Universal SSL limitation that rules out proxying lc.api / babyrite.api
+# is not what is at play here.
+resource "cloudflare_dns_record" "status_page" {
+  zone_id = local.cloudflare_zone_id
+  name    = "status"
+  content = "statuspage.betteruptime.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = false
+  comment = "Better Stack status page"
+}
+
 # Proton Mail DKIM
 resource "cloudflare_dns_record" "protonmail_dkim1" {
   zone_id = local.cloudflare_zone_id


### PR DESCRIPTION
## Why

The repository has no uptime monitoring at all. Nothing notices when s1 goes down, when the Cloudflare Tunnel drops, or when the weekly restic backup fails — the only things in place today are Dozzle (log viewing), Web Analytics (RUM), a single container healthcheck, and a deploy-time restart-count check for chime.

s1 has no port forwarding and is reachable only through Cloudflare Tunnel and Tailscale, so a pull-based HTTP check cannot see the host at all. Monitoring will be run by Better Stack, whose free plan covers push-based heartbeats (which is what s1 needs), a status page on a custom domain, and a vendor-maintained Terraform provider — at no cost.

This PR is only the DNS record. It lands ahead of the Better Stack resources on purpose: setting `custom_domain` on the status page makes Better Stack verify this CNAME, so creating both in a single apply would race the DNS it depends on.

## Why proxied = false

Better Stack terminates TLS on `statuspage.betteruptime.com` and issues its own certificate for this hostname, so the record has to stay DNS-only — proxying it would break HTTPS. `status` is a 1-level subdomain, so the 2-level Universal SSL limitation that rules out proxying `lc.api` / `babyrite.api` is not what is at play here.

## Verification

```
dig +short status.m1sk9.dev CNAME
```

should return `statuspage.betteruptime.com`. The hostname will 404 until the status page itself exists (next PR).

## Follow-ups

- **PR 2** — Better Stack monitors (3), heartbeats (6), status page, Discord webhook, plus a Cloudflare Access service token and a path-scoped `books.m1sk9.dev/healthz` application so the Access-protected origin can be checked end-to-end
- **PR 3** — Ansible `heartbeat` role for the s1-side pushes, and success/failure notification for the restic backup

Generated with Claude Code

https://claude.ai/code/session_01KZpSFnfERk2hG11tsX3tRa