### PR TITLE
feat(betteruptime): monitor s1 and the public sites from Better Stack

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/betterstackhq/better-uptime" {
+  version     = "0.21.10"
+  constraints = "0.21.10"
+  hashes = [
+    "h1:YA1jko6D6H0vT+ars5DS0UJ2DwtW1utZ4DjamlP/wbg=",
+    "h1:n3N1fz0dWg8+x3FL+us6X1LQEg7HCSrljoakt1ckgWI=",
+    "zh:04ef03a90b8b632ba4d28e4cd5ca1f31f04ea1eb8e95df2391a991feea1d9491",
+    "zh:19ade4aac0d2544505d74abbdb03b86e7e1bb76448fa956802687afdbc151872",
+    "zh:3870457bcee93de3cd0d62b5eeaf61a7395d969032d4b1aa48823eca51418144",
+    "zh:3d575d4cf38d4ae3ad39431d5ce15c538493612bc6c5442585a3e6b577ca84a9",
+    "zh:7224d035f4a0a80e8f279bddd71f931130a8366a6da6132826a59ecf975356e2",
+    "zh:7cae9903c0caebc4c1606536d10dcac94184827391950928abca10b75df90de6",
+    "zh:806777e45300b411705f7763fedb2ad233b887830a0c9c036d098eeec0ec2394",
+    "zh:8c09de87613c1fb295f0b0c4a8c04a35545308a161659a72051a4434ddb8cc5f",
+    "zh:a3919b36073be4f24ef07453c1e4ef7be3bc5ef69fb827216f18f3f646d43144",
+    "zh:b38b71c597ef8abc323a8d06587ca0c1df161a7016fcefe67daae5554cb020b5",
+    "zh:bc27c9d8e435300cf17d385bfa1ab19eda0946705f60319332cadabe998e23db",
+    "zh:f07048abb0085985ee1091adefbbc38c3fc8e365ee3055d090065a9c212cde43",
+    "zh:ff225c9ef91801d27e01fbbdf903f893273748aea056dc0b439ef8e6343044af",
+  ]
+}
+
 provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "5.22.0"
   constraints = "5.22.0"

--- a/terraform/betteruptime_heartbeat.tf
+++ b/terraform/betteruptime_heartbeat.tf
@@ -1,0 +1,88 @@
+# Better Stack heartbeats (inbound pushes from s1)
+#
+# s1 has no port forwarding and is reachable only over Cloudflare Tunnel and
+# Tailscale, so nothing outside can poll it. Every check that needs to see the
+# host itself has to be inverted: s1 pushes, and Better Stack raises an incident
+# when the pushes stop. The senders are systemd timers deployed by the Ansible
+# `heartbeat` role; the periods below are the timer interval plus room for one
+# dropped run.
+#
+# The ping URLs are read out of the outputs and stored in the Ansible vault by
+# hand, the same way the R2 credentials are — see outputs.tf.
+
+# s1 itself. Nothing is probed locally: arriving at all is the signal.
+#
+# Note what this actually measures — "s1 can reach the internet", not "s1 is
+# powered on". A home line outage raises this incident with the machine perfectly
+# healthy. From the outside those are the same thing, so that is the right
+# reading, but it is worth knowing before chasing a phantom failure.
+resource "betteruptime_heartbeat" "s1_host" {
+  name   = "s1"
+  period = 300 # timer fires every 2 min, so this tolerates one missed run
+  grace  = 120
+  email  = true
+}
+
+# Wallos' container, checked from inside s1 (see betteruptime_monitor.wallos_edge
+# for the other half of this pair).
+resource "betteruptime_heartbeat" "wallos" {
+  name   = "wallos (origin)"
+  period = 420 # timer fires every 3 min
+  grace  = 180
+  email  = true
+}
+
+# chime reports its container healthcheck rather than mere process liveness.
+#
+# Why this one is stronger than the two below: chime writes a heartbeat file on
+# every scheduler tick and its `chime health` subcommand fails once that file is
+# older than twice the tick interval (30s, so a 60s threshold). Reading the
+# resulting Docker health status proves the scheduler is still running, not just
+# that the process exists. chime posts through Discord webhooks over plain HTTP,
+# so it holds no gateway connection that could rot underneath a healthy process.
+resource "betteruptime_heartbeat" "chime" {
+  name   = "chime"
+  period = 420
+  grace  = 180
+  email  = true
+}
+
+# babyrite and honeypot report container liveness only.
+#
+# Neither image ships a healthcheck, and both hold a websocket to the Discord
+# gateway. A dropped gateway connection inside a running process is therefore
+# invisible here: these two say "the container is up" and nothing more. Closing
+# that gap needs a push from inside the bots themselves, which lives in their own
+# repositories — chime's heartbeat.rs is the worked example.
+resource "betteruptime_heartbeat" "babyrite" {
+  name   = "babyrite"
+  period = 420
+  grace  = 180
+  email  = true
+}
+
+resource "betteruptime_heartbeat" "honeypot" {
+  name   = "honeypot"
+  period = 420
+  grace  = 180
+  email  = true
+}
+
+# The weekly restic backup to R2, which until now failed silently.
+#
+# The unit pings this on success and posts to <url>/fail with the last 50 journal
+# lines when it fails, so a broken run reports immediately instead of waiting out
+# the period. The period only has to catch the third case: s1 being down when the
+# timer was due, so the run never happened at all.
+#
+# server_timezone keeps the weekly window aligned with the Friday 03:00 timer
+# across DST changes. It applies only to periods of an hour or more, which is why
+# the heartbeats above leave it unset. Unlike maintenance_timezone (a Rails zone
+# name) this one takes an IANA name.
+resource "betteruptime_heartbeat" "backup" {
+  name            = "s1-backup"
+  period          = 604800 # 7 days, matching OnCalendar=Fri *-*-* 03:00:00
+  grace           = 21600  # 6 h
+  server_timezone = "Asia/Tokyo"
+  email           = true
+}

--- a/terraform/betteruptime_monitor.tf
+++ b/terraform/betteruptime_monitor.tf
@@ -1,0 +1,109 @@
+# Better Stack monitors (external HTTP checks)
+
+locals {
+  # The free plan floor. Asking for less than this is rejected — 30s checks are
+  # a paid feature.
+  monitor_check_frequency = 180
+
+  # Two regions so that a single unhealthy probe location does not read as an
+  # outage. "as" is the closest to the origin, "us" is the control.
+  monitor_regions = ["as", "us"]
+
+  # Valid options for HTTP monitors are 2, 3, 5, 10, 15, 30, 45 and 60 seconds.
+  # 10 is generous for Cloudflare-fronted hosts but s1 is a Celeron 3855U, so
+  # the origin-backed checks need the headroom.
+  monitor_request_timeout = 10
+
+  # Wait one further check before opening or closing an incident, so a single
+  # dropped request does not page.
+  monitor_confirmation_period = 180
+  monitor_recovery_period     = 180
+}
+
+# m1sk9.dev - Portfolio (Zola static site served by Workers)
+#
+# Why keyword rather than a bare 2xx check: the apex is answered by a Worker, and
+# a Worker that has lost its assets or been deployed empty still returns 200. The
+# title is the cheapest proof that the site actually rendered.
+#
+# This is the only monitor that checks domain expiration: every hostname here
+# lives on m1sk9.dev, so enabling it everywhere would just mean three copies of
+# the same warning.
+resource "betteruptime_monitor" "portfolio" {
+  url              = "https://m1sk9.dev"
+  monitor_type     = "keyword"
+  required_keyword = "Sho Sakuma"
+
+  check_frequency     = local.monitor_check_frequency
+  regions             = local.monitor_regions
+  request_timeout     = local.monitor_request_timeout
+  confirmation_period = local.monitor_confirmation_period
+  recovery_period     = local.monitor_recovery_period
+
+  email             = true
+  ssl_expiration    = 30
+  domain_expiration = 30
+}
+
+# books.m1sk9.dev - PdfDing (Access-protected, behind the s1 tunnel)
+#
+# Checks /healthz with the service token so the request travels the whole path:
+# Cloudflare edge, Access, tunnel, container. Without the token Access would
+# answer with a redirect at the edge and this monitor would stay green with the
+# server switched off. See cloudflare_zero_trust_access_service_token.uptime for
+# why the token is scoped to this one path.
+resource "betteruptime_monitor" "books" {
+  url          = "https://books.m1sk9.dev/healthz"
+  monitor_type = "status"
+
+  request_headers = [
+    {
+      name  = "CF-Access-Client-Id"
+      value = cloudflare_zero_trust_access_service_token.uptime.client_id
+    },
+    {
+      name  = "CF-Access-Client-Secret"
+      value = cloudflare_zero_trust_access_service_token.uptime.client_secret
+    },
+  ]
+
+  check_frequency     = local.monitor_check_frequency
+  regions             = local.monitor_regions
+  request_timeout     = local.monitor_request_timeout
+  confirmation_period = local.monitor_confirmation_period
+  recovery_period     = local.monitor_recovery_period
+
+  email             = true
+  ssl_expiration    = 30
+  domain_expiration = -1
+}
+
+# wallos.m1sk9.dev - Wallos (Access-protected, edge reachability only)
+#
+# Why 302 is the expected result: Wallos has no health endpoint (its compose file
+# disables the container healthcheck outright), so there is no safe path to scope
+# a service token to the way books.m1sk9.dev has /healthz. Pointing a token at
+# `/` would leave a standing credential for the subscription data, so this
+# deliberately checks only that the edge still answers with the Access login
+# redirect — DNS, Cloudflare and the Access configuration.
+#
+# That leaves the tunnel and the container unproven, which is what the
+# betteruptime_heartbeat.wallos push from s1 covers. Neither half is sufficient
+# alone: the redirect is served without ever consulting the origin, and the
+# heartbeat cannot see a Cloudflare-side failure.
+resource "betteruptime_monitor" "wallos_edge" {
+  url                   = "https://wallos.m1sk9.dev"
+  monitor_type          = "expected_status_code"
+  expected_status_codes = [302]
+  follow_redirects      = false
+
+  check_frequency     = local.monitor_check_frequency
+  regions             = local.monitor_regions
+  request_timeout     = local.monitor_request_timeout
+  confirmation_period = local.monitor_confirmation_period
+  recovery_period     = local.monitor_recovery_period
+
+  email             = true
+  ssl_expiration    = 30
+  domain_expiration = -1
+}

--- a/terraform/betteruptime_status_page.tf
+++ b/terraform/betteruptime_status_page.tf
@@ -1,0 +1,175 @@
+# Better Stack status page (status.m1sk9.dev)
+
+# Why the status page is hosted by Better Stack rather than rendered by a Worker:
+# every monitored target sits behind Cloudflare, so a Cloudflare outage is
+# precisely the moment this page matters. Serving it from Workers would take it
+# down together with everything it reports on.
+#
+# Design is limited to what the free plan allows. custom_css and
+# custom_javascript exist as attributes but are billed at $15/page/month, and
+# whitelabeled (dropping the "Powered by Better Stack" footer) at $250, so the
+# look is whatever design/theme/layout can express.
+resource "betteruptime_status_page" "m1sk9" {
+  company_name = "m1sk9"
+  company_url  = "https://m1sk9.dev"
+
+  # Required even with a custom domain, and unique across all of Better Stack —
+  # the page stays reachable at <subdomain>.betteruptime.com as well.
+  subdomain = "m1sk9"
+
+  # Rails TimeZone name, not an IANA one (contrast
+  # betteruptime_heartbeat.backup.server_timezone).
+  timezone = "Tokyo"
+
+  custom_domain = "status.m1sk9.dev"
+  published     = true
+
+  design = "v2" # theme, layout and navigation_links require the modern design
+  theme  = "dark"
+  layout = "vertical"
+
+  history = 90
+
+  # Checks run every 3 minutes, so anything shorter than this is a single failed
+  # probe rather than an outage worth publishing.
+  min_incident_length = 300
+
+  hide_from_search_engines = true
+  subscribable             = true
+
+  navigation_links {
+    text = "m1sk9.dev"
+    href = "https://m1sk9.dev"
+  }
+
+  # The custom domain is verified against the CNAME on creation, so the record
+  # has to exist first.
+  depends_on = [cloudflare_dns_record.status_page]
+}
+
+# --- Sections ---
+
+resource "betteruptime_status_page_section" "server" {
+  status_page_id = betteruptime_status_page.m1sk9.id
+  name           = "Server (s1)"
+  position       = 0
+}
+
+resource "betteruptime_status_page_section" "web" {
+  status_page_id = betteruptime_status_page.m1sk9.id
+  name           = "Web"
+  position       = 1
+}
+
+resource "betteruptime_status_page_section" "self_hosted" {
+  status_page_id = betteruptime_status_page.m1sk9.id
+  name           = "Self-hosted"
+  position       = 2
+}
+
+# --- Server (s1) ---
+
+resource "betteruptime_status_page_resource" "s1_host" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.server.id
+  resource_id            = betteruptime_heartbeat.s1_host.id
+  resource_type          = "Heartbeat"
+  public_name            = "s1"
+  explanation            = "The host pushes a heartbeat every 2 minutes. Reported down when the pushes stop, which includes the home line going out."
+  widget_type            = "history"
+  position               = 0
+}
+
+resource "betteruptime_status_page_resource" "backup" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.server.id
+  resource_id            = betteruptime_heartbeat.backup.id
+  resource_type          = "Heartbeat"
+  public_name            = "s1-backup"
+  explanation            = "Weekly restic backup to Cloudflare R2, Friday 03:00 JST."
+  widget_type            = "history"
+  position               = 1
+}
+
+# --- Web ---
+
+resource "betteruptime_status_page_resource" "portfolio" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.web.id
+  resource_id            = betteruptime_monitor.portfolio.id
+  resource_type          = "Monitor"
+  public_name            = "m1sk9.dev"
+  widget_type            = "response_times"
+  position               = 0
+}
+
+resource "betteruptime_status_page_resource" "books" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.web.id
+  resource_id            = betteruptime_monitor.books.id
+  resource_type          = "Monitor"
+  public_name            = "books.m1sk9.dev"
+  explanation            = "Checked end to end through Cloudflare Access and the tunnel to the container."
+  widget_type            = "response_times"
+  position               = 1
+}
+
+# widget_type is history rather than response_times on purpose: the response time
+# here is Cloudflare answering with the Access redirect, which says nothing about
+# the origin and would read as a suspiciously fast service.
+resource "betteruptime_status_page_resource" "wallos_edge" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.web.id
+  resource_id            = betteruptime_monitor.wallos_edge.id
+  resource_type          = "Monitor"
+  public_name            = "wallos.m1sk9.dev"
+  explanation            = "Edge reachability only — confirms DNS, Cloudflare and Access. The container itself is covered by wallos under Self-hosted."
+  widget_type            = "history"
+  position               = 2
+}
+
+# --- Self-hosted ---
+
+resource "betteruptime_status_page_resource" "wallos" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.self_hosted.id
+  resource_id            = betteruptime_heartbeat.wallos.id
+  resource_type          = "Heartbeat"
+  public_name            = "wallos"
+  explanation            = "Probed on s1 itself, so this covers the tunnel and the container behind wallos.m1sk9.dev."
+  widget_type            = "history"
+  position               = 0
+}
+
+resource "betteruptime_status_page_resource" "chime" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.self_hosted.id
+  resource_id            = betteruptime_heartbeat.chime.id
+  resource_type          = "Heartbeat"
+  public_name            = "chime"
+  explanation            = "Reports its own liveness check, which fails once the scheduler stops ticking."
+  widget_type            = "history"
+  position               = 1
+}
+
+resource "betteruptime_status_page_resource" "babyrite" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.self_hosted.id
+  resource_id            = betteruptime_heartbeat.babyrite.id
+  resource_type          = "Heartbeat"
+  public_name            = "babyrite"
+  explanation            = "Container liveness only — a dropped Discord gateway connection is not visible here."
+  widget_type            = "history"
+  position               = 2
+}
+
+resource "betteruptime_status_page_resource" "honeypot" {
+  status_page_id         = betteruptime_status_page.m1sk9.id
+  status_page_section_id = betteruptime_status_page_section.self_hosted.id
+  resource_id            = betteruptime_heartbeat.honeypot.id
+  resource_type          = "Heartbeat"
+  public_name            = "honeypot"
+  explanation            = "Container liveness only — a dropped Discord gateway connection is not visible here."
+  widget_type            = "history"
+  position               = 3
+}

--- a/terraform/cloudflare_access.tf
+++ b/terraform/cloudflare_access.tf
@@ -96,3 +96,51 @@ resource "cloudflare_zero_trust_access_application" "pdfding" {
     precedence = 1
   }]
 }
+
+# Uptime probe access for PdfDing's health endpoint
+#
+# Why a service token at all: Access answers unauthenticated requests at the edge
+# with a redirect to the IdP, before the origin is ever consulted. An external
+# monitor that treats that redirect as success would be confirming Cloudflare is
+# up and nothing else — it would keep reporting green with s1 unplugged. The
+# token is what lets a probe reach the container and observe a real response.
+#
+# Why a separate path-scoped application instead of adding the token to the
+# PdfDing policy above: Cloudflare evaluates the most specific path first and
+# does not inherit rules from the broader application, so this grants /healthz
+# and nothing else. PdfDing's HealthView is login_not_required and returns an
+# empty 200, so a leaked token buys an attacker a blank page while the library
+# itself stays behind the GitHub IdP.
+#
+# Note that this also means /healthz stops being reachable from a browser signed
+# in as me@m1sk9.dev — non_identity admits service tokens only. That is fine for
+# a health endpoint, but it does surprise you if you go looking.
+resource "cloudflare_zero_trust_access_service_token" "uptime" {
+  account_id = local.cloudflare_account_id
+  name       = "betterstack-uptime"
+  duration   = "8760h" # 1 year; rotate by bumping client_secret_version
+}
+
+resource "cloudflare_zero_trust_access_policy" "pdfding_healthz" {
+  account_id = local.cloudflare_account_id
+  name       = "Allow Better Stack uptime probe"
+  decision   = "non_identity"
+
+  include = [{
+    service_token = {
+      token_id = cloudflare_zero_trust_access_service_token.uptime.id
+    }
+  }]
+}
+
+resource "cloudflare_zero_trust_access_application" "pdfding_healthz" {
+  account_id = local.cloudflare_account_id
+  name       = "PdfDing Health"
+  domain     = "books.m1sk9.dev/healthz"
+  type       = "self_hosted"
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.pdfding_healthz.id
+    precedence = 1
+  }]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -14,3 +14,57 @@ output "account_id" {
   description = "Cloudflare Account ID"
   value       = local.cloudflare_account_id
 }
+
+# Better Stack heartbeat ping URLs
+#
+# These are consumed by the Ansible `heartbeat` role, which cannot read Terraform
+# state. Copy each one into the vault by hand after apply, the same arrangement as
+# the R2 credentials:
+#
+#   terraform output -raw heartbeat_url_s1_host
+#   ansible-vault edit inventory/group_vars/all/vault.yml
+#
+# They are marked sensitive because the URL is the only credential involved —
+# anyone holding it can report the service as healthy. A replaced heartbeat
+# resource issues a new URL, so this is a one-off per heartbeat.
+
+output "heartbeat_url_s1_host" {
+  description = "Better Stack heartbeat URL for the s1 host"
+  value       = betteruptime_heartbeat.s1_host.url
+  sensitive   = true
+}
+
+output "heartbeat_url_wallos" {
+  description = "Better Stack heartbeat URL for the Wallos container on s1"
+  value       = betteruptime_heartbeat.wallos.url
+  sensitive   = true
+}
+
+output "heartbeat_url_chime" {
+  description = "Better Stack heartbeat URL for chime"
+  value       = betteruptime_heartbeat.chime.url
+  sensitive   = true
+}
+
+output "heartbeat_url_babyrite" {
+  description = "Better Stack heartbeat URL for babyrite"
+  value       = betteruptime_heartbeat.babyrite.url
+  sensitive   = true
+}
+
+output "heartbeat_url_honeypot" {
+  description = "Better Stack heartbeat URL for honeypot"
+  value       = betteruptime_heartbeat.honeypot.url
+  sensitive   = true
+}
+
+output "heartbeat_url_backup" {
+  description = "Better Stack heartbeat URL for the weekly restic backup"
+  value       = betteruptime_heartbeat.backup.url
+  sensitive   = true
+}
+
+output "status_page_url" {
+  description = "Public status page URL"
+  value       = "https://${betteruptime_status_page.m1sk9.custom_domain}"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -14,9 +14,17 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "5.22.0"
     }
+    betteruptime = {
+      source  = "BetterStackHQ/better-uptime"
+      version = "0.21.10"
+    }
   }
 }
 
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
+}
+
+provider "betteruptime" {
+  api_token = var.betteruptime_api_token
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,3 +16,10 @@ variable "github_client_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "betteruptime_api_token" {
+  description = "A Better Stack Uptime API token"
+  type        = string
+  sensitive   = true
+  ephemeral   = true
+}


### PR DESCRIPTION
## Why

Nothing in this repository noticed when something broke. s1 could be unplugged, the tunnel could drop, and the weekly restic backup could fail for months without a single notification.

s1 cannot be polled — no port forwarding, reachable only over Cloudflare Tunnel and Tailscale — so every check that needs to see the host is inverted: the host pushes, and Better Stack raises an incident when the pushes stop. The free plan covers that (10 heartbeats), plus a status page on a custom domain and a vendor-maintained provider, at **no cost**.

## What this adds

**25 resources, 0 changes, 0 destroys** — no existing Access application is touched.

| | Count | Notes |
|---|---|---|
| `betteruptime_monitor` | 3 | `m1sk9.dev` (keyword), `books.m1sk9.dev/healthz`, `wallos.m1sk9.dev` (edge) |
| `betteruptime_heartbeat` | 6 | s1 host, wallos origin, chime, babyrite, honeypot, weekly backup |
| `betteruptime_status_page` + sections + resources | 13 | Sections: Server (s1) / Web / Self-hosted |
| Cloudflare Access | 3 | Service token + path-scoped `/healthz` application and its policy |

## Access-protected services need care

Access answers unauthenticated requests **at the edge**, before the origin is consulted. A monitor that accepts that redirect as success would report green with the server switched off — it would be confirming Cloudflare is up and nothing else.

- **books.m1sk9.dev** is checked at `/healthz` with a service token, so the request travels the whole path: edge → Access → tunnel → container. The token is scoped by a **path-specific Access application** rather than added to the existing PdfDing policy: Cloudflare evaluates the most specific path first and does not inherit the broader rule, so a leaked token reaches an endpoint that returns an empty 200 while the library stays behind the GitHub IdP. (Side effect worth knowing: `/healthz` stops being reachable from a signed-in browser, since `non_identity` admits service tokens only.)
- **wallos.m1sk9.dev** has no health endpoint and no safe path to scope a token to — pointing one at `/` would leave a standing credential for the subscription data. It is split instead: the monitor checks only that the edge still returns the Access redirect, and a heartbeat pushed from s1 covers the tunnel and the container. **Neither half is sufficient alone.**

## Bot monitoring is uneven, on purpose

Only **chime** can be checked meaningfully: it writes a heartbeat file on every scheduler tick and fails its own `health` subcommand once that file goes stale, so reading the container health status proves the scheduler is running. **babyrite** and **honeypot** ship no healthcheck and hold Discord gateway websockets, so they report container liveness and nothing more — a dead gateway inside a live process stays invisible until those bots push for themselves (chime's `heartbeat.rs` is the worked example).

This limitation is stated in the status page `explanation` text so the page does not overstate what it knows.

## Discord notification is deliberately absent

`betteruptime_outgoing_webhook` needs template variables that Better Stack does not document (`docs/uptime/webhooks/` has no list, and the provider has no Discord or Slack integration resource). Guessing them would produce broken alerts. **Every monitor and heartbeat has `email = true`** in the meantime, and the webhook follows once the UI's template editor has been read.

## Verification

`terraform validate` and `terraform plan` both pass locally. Three things only apply can settle:

1. **`subdomain = "m1sk9"`** — unique across all of Better Stack. Falls back to `m1sk92`.
2. **`period = 604800`** (restic's 7 days) — provider docs specify a 30s floor but no ceiling.
3. **`custom_domain` on the free plan** — pricing reads as included.

After apply:

```
curl -s -o /dev/null -w '%{http_code}\n' https://status.m1sk9.dev
curl -s -o /dev/null -w '%{http_code}\n' -H "CF-Access-Client-Id: <id>" -H "CF-Access-Client-Secret: <secret>" https://books.m1sk9.dev/healthz
curl -s -o /dev/null -w '%{http_code}\n' https://books.m1sk9.dev/healthz
```

Expect `200` / `200` / `302`. **The third staying 302 is the point** — without the token the path scoping holds.

Heartbeats will read as down until PR 3 deploys the senders.

## Follow-ups

- **PR 3** — Ansible `heartbeat` role (the s1-side systemd timers) and success/failure notification for the restic backup
- **Discord webhook** — once the template variables are known

Generated with Claude Code

https://claude.ai/code/session_01KZpSFnfERk2hG11tsX3tRa