### PR TITLE
fix(betteruptime): stop apply failing on cookies and advanced settings

### DIFF
--- a/terraform/betteruptime_monitor.tf
+++ b/terraform/betteruptime_monitor.tf
@@ -97,6 +97,11 @@ resource "betteruptime_monitor" "wallos_edge" {
   expected_status_codes = [302]
   follow_redirects      = false
 
+  # The API rejects the pair outright ("Cannot keep cookies when redirecting when
+  # expecting a 3xx status code"): remembering cookies only means anything if the
+  # redirect is followed, and here the redirect is the thing being asserted.
+  remember_cookies = false
+
   check_frequency     = local.monitor_check_frequency
   regions             = local.monitor_regions
   request_timeout     = local.monitor_request_timeout

--- a/terraform/betteruptime_status_page.tf
+++ b/terraform/betteruptime_status_page.tf
@@ -5,10 +5,24 @@
 # precisely the moment this page matters. Serving it from Workers would take it
 # down together with everything it reports on.
 #
-# Design is limited to what the free plan allows. custom_css and
-# custom_javascript exist as attributes but are billed at $15/page/month, and
-# whitelabeled (dropping the "Powered by Better Stack" footer) at $250, so the
-# look is whatever design/theme/layout can express.
+# What this resource deliberately does not set, and why:
+#
+# The free plan refuses API writes to anything the dashboard files under
+# "Advanced settings" — "Cannot modify status page advanced settings. Please
+# upgrade your account to modify advanced status page settings." Some of those
+# are billed features (custom_css and custom_javascript at $15/page/month,
+# whitelabeled / password_enabled / ip_allowlist / require_sso far above that),
+# but others are free to set by hand and simply not reachable through the API:
+# history, min_incident_length, hide_from_search_engines, navigation_links and
+# even published. Those are configured in the dashboard — including flipping the
+# page to published, which is why this resource cannot do it. Leaving them out of
+# the configuration means Terraform does not diff against them, so the manual
+# values survive. subscribable is billed, so it stays off entirely.
+#
+# Everything below sits outside that section and applies cleanly: the identity
+# fields, the whole Personalization block (design / theme / layout) and — despite
+# what the pricing page's "Custom sub-domain" wording suggests — the custom
+# domain.
 resource "betteruptime_status_page" "m1sk9" {
   company_name = "m1sk9"
   company_url  = "https://m1sk9.dev"
@@ -22,25 +36,10 @@ resource "betteruptime_status_page" "m1sk9" {
   timezone = "Tokyo"
 
   custom_domain = "status.m1sk9.dev"
-  published     = true
 
-  design = "v2" # theme, layout and navigation_links require the modern design
+  design = "v2" # theme and layout require the modern design
   theme  = "dark"
   layout = "vertical"
-
-  history = 90
-
-  # Checks run every 3 minutes, so anything shorter than this is a single failed
-  # probe rather than an outage worth publishing.
-  min_incident_length = 300
-
-  hide_from_search_engines = true
-  subscribable             = true
-
-  navigation_links {
-    text = "m1sk9.dev"
-    href = "https://m1sk9.dev"
-  }
 
   # The custom domain is verified against the CNAME on creation, so the record
   # has to exist first.


### PR DESCRIPTION
## Why

The apply from #330 created the six heartbeats and the `m1sk9.dev` monitor, then stopped on three failures. This fixes the two that need code.

| Failure | Cause | Fix |
|---|---|---|
| `betteruptime_monitor.wallos_edge` → **422** | `follow_redirects = false` but `remember_cookies` defaults to true | `remember_cookies = false` |
| `betteruptime_status_page.m1sk9` → **403** | Free plan refuses API writes to anything under the dashboard's "Advanced settings" | Drop those attributes; configure them by hand |
| `cloudflare_zero_trust_access_service_token.uptime` → **403** | Cloudflare API token lacked `Access: Service Tokens` | **Already granted — no code change** |

## The cookie conflict

```
422: Cannot keep cookies when redirecting when expecting a 3xx status code
```

Keeping cookies across a redirect only means something if the redirect is followed, and this monitor asserts the redirect itself rather than chasing it. `follow_redirects` was already false; `remember_cookies` now says so too.

## The advanced settings wall

```
403: Cannot modify status page advanced settings.
Please upgrade your account to modify advanced status page settings.
```

That section mixes **billed** features (Custom CSS/JS at \$15/page/month, white-labeling / password / IP allowlist / SSO far above) with ones that are **free to set by hand but unreachable over the API**. So the error is not a billing signal on its own.

Moved to the dashboard: `history`, `min_incident_length`, `hide_from_search_engines`, `navigation_links`, `published`. Omitting them here keeps Terraform from diffing against the manual values, so those settings survive. `subscribable` is billed, so it goes entirely.

**What survives is what matters for the look**: `design`, `theme` and `layout` sit outside that section, and so does `custom_domain` — the pricing page's "Custom sub-domain" wording suggested otherwise, but `status.m1sk9.dev` works on the free plan.

## Manual dashboard steps after merge

Advanced settings → set `90 days` history, a minimum incident length above 0, tick *Hide from search engines*, and **flip *Status page access* to Published** (the page is not public without it).

## Verification

`fmt`, `tflint` and `validate` pass. The real test is apply: 18 resources remain, and the 13 status-page-related ones are what this unblocks.

Generated with Claude Code

https://claude.ai/code/session_01KZpSFnfERk2hG11tsX3tRa