### PR TITLE
chore(betteruptime): name the status page "m1sk9's infra"

### DIFF
--- a/terraform/betteruptime_status_page.tf
+++ b/terraform/betteruptime_status_page.tf
@@ -24,8 +24,9 @@
 # what the pricing page's "Custom sub-domain" wording suggests — the custom
 # domain.
 resource "betteruptime_status_page" "m1sk9" {
-  # Shown as the page heading, so it names the page rather than the owner.
-  company_name = "status.m1sk9.dev"
+  # Better Stack renders this as "<company_name> status", so it holds the name
+  # alone. Putting the hostname here reads as "status.m1sk9.dev status".
+  company_name = "m1sk9's infra"
   company_url  = "https://m1sk9.dev"
 
   # Required even with a custom domain, and unique across all of Better Stack —


### PR DESCRIPTION
## Why

Better Stack renders `company_name` as **"&lt;company_name&gt; status"**, so naming it after the hostname produced:

```
og:title = "status.m1sk9.dev status"
```

This holds the name alone, giving `m1sk9's infra status`.

Note that the browser `<title>` stays `Better Stack` regardless — that is tied to white-labeling ($250/page/month), not to this attribute.

## Verification

```
Plan: 0 to add, 1 to change, 0 to destroy.
~ company_name = "status.m1sk9.dev" -> "m1sk9's infra"
```

Generated with Claude Code

https://claude.ai/code/session_01KZpSFnfERk2hG11tsX3tRa