### PR TITLE
fix(ansible): survive Tailscale netmap propagation on CI connections

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -5,6 +5,11 @@ roles_path = roles
 host_key_checking = True
 interpreter_python = auto_silent
 nocows = True
+# CI/CD connect from an ephemeral Tailscale node. s1 learns the new peer only
+# after a netmap update (~14s observed) and silently drops packets until then,
+# so the 10s default gives up before the tunnel is usable.
+timeout = 30
 
 [ssh_connection]
 pipelining = True
+retries = 3


### PR DESCRIPTION
## Why

PR #338 の `ansible-plan` が `tailscale up` 成功後にも `UNREACHABLE! ... Connection timed out` で落ちていた。両側のログを突き合わせると、ホストや ACL の問題ではなく **netmap 伝播レース** だった:

| 時刻 (UTC) | 出来事 |
|---|---|
| 09:22:05 | CI: `tailscale up` 成功 |
| 09:22:06 | CI: s1 への最初の SSH 試行 |
| 09:22:16 | CI: 10 秒（既定 timeout）で断念 |
| 09:22:19 | s1: tailscaled netmap Reconfig、CI peer を認識 |

netmap 更新が届くまで s1 は未知の ephemeral node からのパケットを黙って捨てるため、SYN が無応答になり client 側には timeout として見える。伝播遅延の実測は約 14 秒で、既定の 10 秒では tunnel が使える前に諦めてしまう。

切り分けで除外した要因: s1 は健全（uptime 3 日 / tailscaled 無再起動 / `tag:server-s1` 保持）、ACL は当該 PR で未変更で `tag:ci` → `tag:server-s1` の ssh accept も有効、Tailscale の接続自体は成功。

## What

- `[defaults] timeout = 30` — 観測した伝播遅延を上回る接続 timeout
- `[ssh_connection] retries = 3` — ssh プラグインの `reconnection_retries` にマップし、rc 255 の接続エラーを再試行

workflow ではなく `ansible.cfg` に置いたのは、**CD (`ansible-deploy`) も同じ設定を継承する**ため。main への merge は本番へ auto-apply されるので、plan 経路と同等以上に deploy 経路で必要になる。

## Verification

`ansible/` で CI と同一コマンドを実行し、すべて pass:

- `--syntax-check` × 4 playbook
- `services.yml --check --diff` → ok=28 changed=1（babyrite tag 差分、#338 由来で期待通り）
- `backup.yml` / `monitoring.yml --check --diff` → changed=0
- `ansible-config dump --type connection` で `DEFAULT_TIMEOUT = 30` / `reconnection_retries = 3` の反映を確認

レース自体はローカルで再現できない（laptop は既に tailnet の確立済み peer なので伝播待ちが起きない）。

Generated with Claude Code