### PR TITLE
feat: manage s1's weekly maintenance reboot as IaC

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -72,6 +72,9 @@ jobs:
       - name: Deploy monitoring
         run: ansible-playbook playbooks/monitoring.yml
 
+      - name: Deploy maintenance schedules
+        run: ansible-playbook playbooks/maintenance.yml
+
       - name: Cleanup
         if: always()
         run: rm -f .vault_pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,7 @@ jobs:
           ansible-playbook playbooks/services.yml --syntax-check
           ansible-playbook playbooks/backup.yml --syntax-check
           ansible-playbook playbooks/monitoring.yml --syntax-check
+          ansible-playbook playbooks/maintenance.yml --syntax-check
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
@@ -76,6 +77,7 @@ jobs:
           ansible-playbook playbooks/services.yml --check --diff
           ansible-playbook playbooks/backup.yml --check --diff
           ansible-playbook playbooks/monitoring.yml --check --diff
+          ansible-playbook playbooks/maintenance.yml --check --diff
 
       - name: Cleanup
         if: always()

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -23,13 +23,19 @@ ansible/
 │       ├── vars.yml                 # non-sensitive variables; references vault_ secrets
 │       └── vault.yml                # ansible-vault encrypted secrets
 ├── roles/
-│   └── docker_compose_app/          # generic "deploy a compose stack" role
-│       ├── tasks/main.yml
-│       ├── defaults/main.yml
-│       └── files/<service>/         # compose.yaml + vault-encrypted env/config
+│   ├── docker_compose_app/          # generic "deploy a compose stack" role
+│   │   ├── tasks/main.yml
+│   │   ├── defaults/main.yml
+│   │   └── files/<service>/         # compose.yaml + vault-encrypted env/config
+│   ├── restic_backup/               # weekly restic backup to Cloudflare R2
+│   ├── heartbeat/                   # Better Stack heartbeat senders (systemd timers)
+│   └── scheduled_reboot/            # weekly maintenance reboot (systemd timer)
 └── playbooks/
     ├── site.yml                     # connectivity check
-    └── services.yml                 # deploy all Docker Compose services
+    ├── services.yml                 # deploy all Docker Compose services
+    ├── backup.yml                   # restic backup script and timer
+    ├── monitoring.yml               # heartbeat senders
+    └── maintenance.yml              # scheduled reboot
 ```
 
 ## Hosts
@@ -200,6 +206,47 @@ sudo bash -c 'set -a; . /etc/restic/s1-backup.env; restic restore latest --tag w
 sqlite3 /tmp/restore/.../wallos.db 'PRAGMA integrity_check;'
 ```
 
+## Scheduled reboot
+
+s1 is a repurposed laptop pressed into service as a always-on server, and it is
+rebooted every **Sunday 04:00 JST** to stay stable across weeks of uptime. The
+`scheduled_reboot` role owns that schedule (`s1-reboot.timer` →
+`s1-reboot.service` → `systemctl reboot`). Deploy it with:
+
+```fish
+ansible-playbook playbooks/maintenance.yml
+```
+
+**This is deliberate maintenance, not housekeeping — do not remove it without a
+replacement.** It was a hand-made unit on the host (`reboot-daily.timer`, named
+"daily" while firing weekly) until it was brought in here; the role deletes those
+files so the reboot cannot be scheduled from two places.
+
+Applying the role never reboots s1. Starting a `.timer` arms the schedule without
+running its `.service`, and the timer sets `Persistent=false`, so a window missed
+while s1 was down is not caught up on the next boot — a host that just booted has
+none of the accumulated state this reboot exists to clear.
+
+Every service comes back on its own: `systemctl reboot` stops `docker.service`
+through the normal shutdown transaction, and each stack is declared
+`restart: unless-stopped`. Measured on 2026-08-02, the whole cycle took just over
+two minutes end to end (reboot at 04:00:02, PdfDing serving again at 04:02:08).
+
+### The reboot and the monitors
+
+That two-minute gap is long enough for `betteruptime_monitor.books` to open an
+incident, because `/healthz` is the one external check that travels all the way to
+a container. It carries a matching **maintenance window (Sunday 04:00–04:15
+Tokyo)** in [`terraform/betteruptime_monitor.tf`](../terraform/betteruptime_monitor.tf)
+— **change `reboot_oncalendar` and that window has to move with it**, or the
+status page reports a failure every week for a reboot working as intended.
+
+Nothing else needs one. `wallos_edge` is answered by Cloudflare without consulting
+the origin, and the heartbeats each tolerate a missed run — the same reboot left a
+234 s gap in `s1_host` against its 420 s budget and 366 s in the service
+heartbeats against 600 s. `s1_host` is deliberately left without a window, so a
+reboot that fails to come back is still reported.
+
 ## Monitoring
 
 s1 is reachable only over Cloudflare Tunnel and Tailscale, so nothing outside can
@@ -305,12 +352,13 @@ GitHub Actions deploys this configuration automatically, mirroring the Terraform
 
 - **CI** ([`ci.yaml`](../.github/workflows/ci.yaml)) — on every pull request:
   runs `--syntax-check` on all playbooks, then a **plan**
-  (`--check --diff` for `services.yml`, `backup.yml` and `monitoring.yml`) against s1
-  so the PR shows exactly what would change — the Terraform `plan` equivalent. The
-  `docker_compose_v2` module supports check mode, so the diff is meaningful.
+  (`--check --diff` for `services.yml`, `backup.yml`, `monitoring.yml` and
+  `maintenance.yml`) against s1 so the PR shows exactly what would change — the
+  Terraform `plan` equivalent. The `docker_compose_v2` module supports check mode,
+  so the diff is meaningful.
 - **CD** ([`cd.yaml`](../.github/workflows/cd.yaml)) — on push to `main`
   (or manual `workflow_dispatch`): joins the tailnet, then runs `services.yml`,
-  `backup.yml` and `monitoring.yml` against s1.
+  `backup.yml`, `monitoring.yml` and `maintenance.yml` against s1.
 
 Both workflows run their full job set on every PR and push — there is no
 `paths`-based gating, so an Ansible-only change still runs the Terraform jobs and

--- a/ansible/playbooks/maintenance.yml
+++ b/ansible/playbooks/maintenance.yml
@@ -1,0 +1,9 @@
+---
+- name: Configure s1 maintenance schedules
+  hosts: s1
+  become: true
+
+  tasks:
+    - name: Schedule the weekly reboot
+      ansible.builtin.include_role:
+        name: scheduled_reboot

--- a/ansible/roles/scheduled_reboot/defaults/main.yml
+++ b/ansible/roles/scheduled_reboot/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# s1 is a repurposed laptop, and a scheduled reboot is what keeps it stable over
+# weeks of uptime. This is load-bearing maintenance, not housekeeping — see the
+# README section "Scheduled reboot" before changing or removing it.
+reboot_unit_name: s1-reboot
+
+# systemd timer schedule. Kept in sync by hand with the Better Stack maintenance
+# window on `betteruptime_monitor.books` (terraform/betteruptime_monitor.tf):
+# moving this without moving that brings back a weekly false incident.
+reboot_oncalendar: "Sun *-*-* 04:00:00"
+
+# Unit files left behind by the hand-made timer this role replaces. Removed on
+# every run so the reboot can never be scheduled from two places at once.
+reboot_legacy_units:
+  - reboot-daily.timer
+  - reboot-daily.service

--- a/ansible/roles/scheduled_reboot/tasks/main.yml
+++ b/ansible/roles/scheduled_reboot/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# The unit this role replaces was created by hand on s1 in 2025 and never lived
+# in this repository. It is stopped and removed before the new units are written
+# so that a single run cannot leave two timers both calling `systemctl reboot`.
+- name: "reboot | Look for the hand-made timer this role replaces"
+  ansible.builtin.stat:
+    path: /etc/systemd/system/reboot-daily.timer
+  register: reboot_legacy_timer
+
+- name: "reboot | Stop and disable the hand-made timer"
+  ansible.builtin.systemd_service:
+    name: reboot-daily.timer
+    enabled: false
+    state: stopped
+  when:
+    - reboot_legacy_timer.stat.exists
+    - not ansible_check_mode
+
+- name: "reboot | Remove the hand-made unit files"
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ item }}"
+    state: absent
+  loop: "{{ reboot_legacy_units }}"
+
+- name: "reboot | Deploy systemd service"
+  ansible.builtin.template:
+    src: s1-reboot.service.j2
+    dest: "/etc/systemd/system/{{ reboot_unit_name }}.service"
+    mode: "0644"
+    owner: root
+    group: root
+
+- name: "reboot | Deploy systemd timer"
+  ansible.builtin.template:
+    src: s1-reboot.timer.j2
+    dest: "/etc/systemd/system/{{ reboot_unit_name }}.timer"
+    mode: "0644"
+    owner: root
+    group: root
+
+# The unit files are only rendered for real outside check mode, so activating the
+# timer would fail on the absent unit during a plan. Same guard as restic_backup.
+#
+# Starting a .timer arms the schedule without running its .service, and
+# Persistent=false means there is no catch-up run either — so applying this role
+# never reboots s1, however overdue the window is.
+- name: "reboot | Enable and start timer"
+  ansible.builtin.systemd_service:
+    name: "{{ reboot_unit_name }}.timer"
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: not ansible_check_mode

--- a/ansible/roles/scheduled_reboot/templates/s1-reboot.service.j2
+++ b/ansible/roles/scheduled_reboot/templates/s1-reboot.service.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Scheduled maintenance reboot of s1
+
+[Service]
+Type=oneshot
+# `systemctl reboot` rather than a direct `reboot`: it goes through systemd's
+# ordinary shutdown transaction, so docker.service stops its containers with
+# SIGTERM and every stack marked `restart: unless-stopped` comes back on boot.
+ExecStart=/usr/bin/systemctl reboot

--- a/ansible/roles/scheduled_reboot/templates/s1-reboot.timer.j2
+++ b/ansible/roles/scheduled_reboot/templates/s1-reboot.timer.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Schedule the weekly maintenance reboot of s1
+
+[Timer]
+OnCalendar={{ reboot_oncalendar }}
+# Deliberately not Persistent=true, unlike s1-backup.timer: this reboot exists to
+# clear state accumulated over a week of uptime, and a host that just booted has
+# none. Catching up on a window missed while s1 was down would spend real
+# downtime rebooting a machine that is already fresh.
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/terraform/betteruptime_heartbeat.tf
+++ b/terraform/betteruptime_heartbeat.tf
@@ -16,6 +16,11 @@
 # powered on". A home line outage raises this incident with the machine perfectly
 # healthy. From the outside those are the same thing, so that is the right
 # reading, but it is worth knowing before chasing a phantom failure.
+#
+# This is also the check that stays awake through the weekly maintenance reboot:
+# it carries no maintenance window, unlike betteruptime_monitor.books, and a normal
+# reboot fits inside the budget below with room to spare (234 s of the 420 s on
+# 2026-08-02). A reboot that fails to come back therefore still reports here.
 resource "betteruptime_heartbeat" "s1_host" {
   name   = "s1"
   period = 300 # timer fires every 2 min, so this tolerates one missed run

--- a/terraform/betteruptime_monitor.tf
+++ b/terraform/betteruptime_monitor.tf
@@ -48,6 +48,29 @@ resource "betteruptime_monitor" "books" {
   confirmation_period = local.monitor_confirmation_period
   recovery_period     = local.monitor_recovery_period
 
+  # Suppressed during s1's weekly maintenance reboot, scheduled by the Ansible
+  # `scheduled_reboot` role — move one and the other has to move with it.
+  #
+  # Why this monitor alone needs the window: it is the only check that travels to
+  # the container, so it is the only one the reboot can fail. wallos_edge is
+  # answered by Cloudflare without consulting the origin, and every heartbeat
+  # tolerates a missed run (the 2026-08-02 reboot left a 234 s gap in s1_host
+  # against its 420 s budget, and 366 s in the service heartbeats against 600 s).
+  #
+  # The window is far wider than the outage it covers — 04:00:02 to 04:02:08 on
+  # 2026-08-02 — because a forced fsck of the 865 GiB /home would stretch the boot
+  # well past two minutes, and a window sized to the good case would leak an
+  # incident the first time that happened. Nothing goes unwatched in the meantime:
+  # betteruptime_heartbeat.s1_host has no maintenance window and still fails 420 s
+  # after the pushes stop, so a reboot that never comes back is still reported.
+  #
+  # maintenance_timezone takes a Rails zone name, not an IANA one — "Tokyo", not
+  # "Asia/Tokyo". Contrast server_timezone in betteruptime_heartbeat.tf.
+  maintenance_from     = "04:00:00"
+  maintenance_to       = "04:15:00"
+  maintenance_days     = ["sun"]
+  maintenance_timezone = "Tokyo"
+
   # domain_expiration is 30 on both monitors rather than disabled on one, because
   # Better Stack ignores -1 and keeps 30 anyway — asking for -1 just produces a
   # diff on every plan, forever. Both hostnames are on m1sk9.dev, so the
@@ -71,6 +94,10 @@ resource "betteruptime_monitor" "books" {
 # betteruptime_heartbeat.wallos push from s1 covers. Neither half is sufficient
 # alone: the redirect is served without ever consulting the origin, and the
 # heartbeat cannot see a Cloudflare-side failure.
+#
+# The same blindness is why this one carries no maintenance window for the weekly
+# reboot: with the origin out of the picture there is nothing for the reboot to
+# take down here. See books above.
 resource "betteruptime_monitor" "wallos_edge" {
   url                   = "https://wallos.m1sk9.dev"
   monitor_type          = "expected_status_code"


### PR DESCRIPTION
## Why

s1 rebooted itself at 04:00 JST on 2026-08-02, took PdfDing down for just over two minutes, and opened an incident on status.m1sk9.dev.

The reboot was intentional — s1 is a repurposed laptop and the weekly reboot is what keeps it stable — but nothing about it was visible from this repository. It came from `reboot-daily.timer`, created by hand on the host in 2025 (`reboot-daily.service` mtime 2025-10-28) and named "daily" while actually firing `OnCalendar=Sun 04:00:00`. A schedule that reboots the only server we have does not belong outside IaC.

### Timeline (JST, 2026-08-02)

| Time | Event |
|---|---|
| 04:00:02 | `reboot-daily.timer` → `systemctl reboot`; SIGTERM to cloudflared / docker / pdfding |
| 04:00:03 | PdfDing's gunicorn master exits |
| 04:00:49 | Kernel boots |
| 04:01:19 | `docker.service` and `cloudflared` start |
| 04:01:24 | Tunnel connections re-established |
| 04:02:08 | gunicorn listening on `0.0.0.0:8000` again |

PdfDing was unavailable for **2 m 6 s**. No crash, no OOM, no application error — it took SIGTERM cleanly and came back cleanly.

### Why only PdfDing alerted

The incident was correct reporting, not a monitoring bug. `betteruptime_monitor.books` is the only external check that travels past the Cloudflare edge to a container, so it is the only one a reboot can fail:

| Check | Behaviour during the reboot | Result |
|---|---|---|
| `monitor.books` | `/healthz` through edge → Access → tunnel → container | **incident** |
| `monitor.wallos_edge` | Access login redirect, answered at the edge; never consults the origin | green |
| `heartbeat.s1_host` | 420 s budget vs. a measured 234 s gap (03:58:14 → 04:02:08) | green |
| `heartbeat.wallos` + 3 | 600 s budget vs. a measured 366 s gap (03:57:05 → 04:03:11) | green |

## What changed

**`scheduled_reboot` role + `playbooks/maintenance.yml`** — owns `s1-reboot.timer` → `s1-reboot.service` → `systemctl reboot`, and stops, disables and deletes the hand-made `reboot-daily.*` units so the reboot can never be scheduled from two places. Wired into the CI plan and the CD deploy alongside the other playbooks.

`Persistent=false` departs from the unit it replaces: this reboot exists to clear state accumulated over a week of uptime, so catching up on a window missed while s1 was down would spend real downtime rebooting a host that is already fresh.

Applying the role never reboots s1 — starting a `.timer` arms the schedule without running its `.service`, and there is no catch-up run.

**`betteruptime_monitor.books`** — a matching maintenance window (Sunday 04:00–04:15 `Tokyo`), so the status page stops reporting a weekly failure for a reboot working as intended. `maintenance_days` also narrows from the provider's default of all seven days to `["sun"]`.

The window is far wider than the outage it covers because a forced fsck of the 865 GiB `/home` would stretch the boot well past two minutes, and a window sized to the good case would leak an incident the first time that happened. `heartbeat.s1_host` is deliberately left without a window, so a reboot that never comes back is still reported.

## Verification

- `terraform fmt -check -recursive`, `tflint`, `terraform validate` — pass
- `terraform plan` — 2 in-place updates; `books` (`id = 4749139`, the monitor in the incident) gains the window
- `ansible-playbook playbooks/maintenance.yml --syntax-check` — pass
- `ansible-playbook playbooks/maintenance.yml --check --diff` against s1 — `changed=3` (two legacy units removed, two new units rendered), activation correctly skipped in check mode

## Out of scope

- The `domain_expiration = -1 -> 30` drift on both monitors is pre-existing and unrelated. The comment in `betteruptime_monitor.tf` predicts that asking for `-1` diffs forever, but the plan shows `30` diffs forever too, so the workaround is not achieving what it documents. Left alone here.
- `compose-cd.timer` / `compose-cd-cleanup.timer` still appear in `systemctl list-timers` on s1 with no unit files behind them — leftovers from a removed mechanism, harmless.

Generated with Claude Code
