### PR TITLE
feat: add the ledger-archive R2 bucket for Ledger's Discord archive

### DIFF
--- a/terraform/cloudflare_r2_bucket.tf
+++ b/terraform/cloudflare_r2_bucket.tf
@@ -15,3 +15,26 @@ resource "cloudflare_r2_bucket" "s1_backup" {
   name       = "s1-backup"
   location   = "apac"
 }
+
+# R2 bucket for Ledger's Discord chat archive (github.com/m1sk9/Ledger).
+#
+# Ledger exports Discord chat history as NDJSON, one line per message, plus a
+# manifest.json describing which channels and time ranges have been archived.
+# The viewer on ledger.m1sk9.dev reads both straight out of this bucket through
+# a Worker's R2 binding, so the bucket is the storage layer and the source of
+# truth for the site — there is no database behind it.
+#
+# Why the bucket stays private: the archive is a copy of a private Discord
+# server's history, so it must never be reachable object-by-object. No managed
+# r2.dev domain and no custom domain is attached here; the only reader is the
+# Worker, which is what applies access control before returning anything.
+#
+# The Worker itself is not here for the same reason the portfolio's is not (see
+# cloudflare_worker.tf): the script is a build artifact of the Ledger
+# repository, deployed by wrangler. Terraform owns the bucket and the routing,
+# wrangler owns the script and its R2 binding.
+resource "cloudflare_r2_bucket" "ledger_archive" {
+  account_id = local.cloudflare_account_id
+  name       = "ledger-archive"
+  location   = "apac"
+}


### PR DESCRIPTION
## Why

[Ledger](https://github.com/m1sk9/Ledger) backs up a private Discord server's chat history and publishes it as a web viewer, which will live at `ledger.m1sk9.dev` on Workers. The export is NDJSON (one line per message) plus a `manifest.json` describing which channels and time ranges are archived, and the viewer reads both straight out of R2 — there is no database behind the site. The bucket is the whole storage layer, so it has to exist before anything else can be built.

The bucket stays private: the archive is a copy of a private server's history, so no `r2.dev` managed domain and no custom domain is attached to it. The only reader is the Worker, which is where access control belongs.

## Why this is only the bucket

No Worker script and no custom domain here on purpose. The script `ledger-web` does not exist yet — wrangler has to deploy it first, and `cloudflare_workers_custom_domain` cannot reference a service that is not there. The hostname follows in a separate PR once the script is deployed.

The ownership split is the same one the portfolio already uses (see the comment on `cloudflare_workers_route.portfolio`): wrangler owns the script and its R2 binding, Terraform owns the bucket and the routing.

## Note

The R2 *S3 API token* for Ledger's writer, like `s1-backup`'s, cannot be provisioned by Terraform and has to be issued from the dashboard when the exporter is wired up.

Generated by Claude Code