### PR TITLE
feat: publish the Ledger viewer at ledger.m1sk9.dev

### DIFF
--- a/terraform/cloudflare_worker.tf
+++ b/terraform/cloudflare_worker.tf
@@ -98,3 +98,27 @@ resource "cloudflare_workers_script_subdomain" "working" {
   enabled          = false
   previews_enabled = false
 }
+
+# ledger.m1sk9.dev - Ledger's Discord chat archive viewer
+#
+# Why `service` is a string literal and not a cloudflare_workers_script
+# reference: the script is a build artifact of the Ledger repository, deployed
+# by wrangler, which reads the archive out of cloudflare_r2_bucket.ledger_archive
+# through an R2 binding wrangler also owns. Same boundary as the portfolio above:
+# wrangler owns the script, Terraform owns the routing.
+#
+# Why a custom domain and not a workers_route like the portfolio: a route needs
+# an existing proxied record to attach to, and ledger.m1sk9.dev has none. With no
+# record to adopt there is nothing to destroy and recreate, so the custom domain
+# creates the hostname itself — the same shape as blog, ua and working.
+#
+# Why not a cloudflare_workers_script_subdomain like its neighbours: the exposure
+# is already disabled on the wrangler side (`workers_dev: false` in Ledger's
+# wrangler.jsonc). Since wrangler owns this script, Terraform holding the same
+# setting would mean the two fighting over it on every deploy.
+resource "cloudflare_workers_custom_domain" "ledger" {
+  account_id = local.cloudflare_account_id
+  zone_id    = local.cloudflare_zone_id
+  hostname   = "ledger.m1sk9.dev"
+  service    = "ledger-web"
+}


### PR DESCRIPTION
## Why

The Worker script `ledger-web` is deployed (version `56ba3612-0a51-46e5-90ad-46824a7b552f`) but has **No targets deployed**, so no hostname reaches it. This adds the custom domain that makes the viewer reachable, completing the pair started by `cloudflare_r2_bucket.ledger_archive` (#357).

## Why a custom domain and not a route

`ledger.m1sk9.dev` has no existing proxied DNS record. A route needs one to attach to; the portfolio uses a route specifically to avoid destroying and recreating the apex record it had to adopt. With no record to adopt here, letting the custom domain create the hostname itself is both simpler and the shape `blog` / `ua` / `working` already use.

## Ownership boundary

`service` is a plain string literal rather than a `cloudflare_workers_script` reference, like the portfolio's route: the script is a build artifact of the [Ledger](https://github.com/m1sk9/Ledger) repository, deployed by wrangler, and Terraform cannot own content it does not build. Wrangler also owns the R2 binding that reads `ledger-archive`.

No `cloudflare_workers_script_subdomain` here for the flip side of that boundary — the exposure is already disabled by `workers_dev: false` in Ledger's `wrangler.jsonc`, and Terraform holding the same setting would mean the two fighting over it on every deploy.

## Note on the plan

The plan carries the two known `betteruptime_monitor` changes (`domain_expiration` `-1 -> 30` on `books` and `wallos_edge`). That is pre-existing drift Better Stack re-introduces on its side; it rides on every plan and is unrelated to this change.

Generated by Claude Code