### PR TITLE
Stop Hermes restarting on every unrelated merge to main

### DIFF
--- a/ansible/playbooks/services.yml
+++ b/ansible/playbooks/services.yml
@@ -82,9 +82,13 @@
         app_files:
           - src: hermes/env
             dest: "{{ ansible_facts['env']['HOME'] }}/services/hermes/.env"
+          # 0640, not 0644: Hermes tightens this file's mode itself on startup.
+          # Declaring the looser mode makes copy reset it on every run, and the
+          # role recreates the stack whenever a deployed file changed — so the
+          # container would restart on every unrelated merge to main.
           - src: hermes/config.yaml
             dest: "{{ ansible_facts['env']['HOME'] }}/hermes-data/config.yaml"
-            mode: "0644"
+            mode: "0640"
           - src: hermes/SOUL.md
             dest: "{{ ansible_facts['env']['HOME'] }}/hermes-data/SOUL.md"
             mode: "0644"


### PR DESCRIPTION
Hermes tightens `config.yaml` to `0640` when it starts. Ansible deployed it as `0644`, so `copy` reset the mode on the next run — and `docker_compose_app` recreates the stack whenever a deployed file reports `changed`. The result: the container restarted on every merge to main, Renovate's included, for no reason connected to Hermes.

## The content never drifted

Worth stating, because the file's size and mode changing after the first deploy looks like a rewrite and is not one. A byte comparison after the real deploy:

```
ours : 0c2943ea1f3622403ee194e6d366f54350cd65fad8058766294bdb50a18a42d6  5967
s1   : 0c2943ea1f3622403ee194e6d366f54350cd65fad8058766294bdb50a18a42d6  5967
```

Identical. Hermes leaves the file alone; it only chmods it. So this needed a one-word fix rather than a change of approach — `config.yaml` can stay declaratively managed.

## Measured

`ansible-playbook playbooks/services.yml --check` against s1, after the deploy of #369:

| | before | after |
|---|---|---|
| PLAY RECAP | `ok=33 changed=1` | `ok=33 changed=0` |

Per-file, the deployed set was already almost clean — `.env` (0600) and `SOUL.md` (0644) both reported `ok`; only `config.yaml` reported `changed`.

`0640` is also the better mode on its own terms: the container runs as the owning uid, so nothing needs the world-readable bit.

Generated with Claude Code