### PR TITLE
Point Hermes at the orcarouter/meai route

### DIFF
--- a/ansible/roles/docker_compose_app/files/hermes/config.yaml
+++ b/ansible/roles/docker_compose_app/files/hermes/config.yaml
@@ -13,11 +13,18 @@ providers:
 
 model:
   provider: "orcarouter"
-  default: "deepseek/deepseek-v4-flash-free"
-  # Stated by the vendor, not discoverable: OrcaRouter's /v1/models returns a
-  # null context_length for the -free variants, so auto-detection has nothing
-  # to read and would fall back to a generic window.
-  context_length: 1048576
+  # An account-scoped route, so it appears only on the authenticated /v1/models
+  # listing — the public catalogue does not have it. Being a route rather than a
+  # model, what actually answers can change without anything here changing.
+  default: "orcarouter/meai"
+  # The listing reports a null context_length for this route, so auto-detection
+  # has nothing to read. Pinned low on purpose: the two errors are not
+  # symmetric. Too small only compresses earlier than it had to; too large lets
+  # Hermes build a request the upstream then rejects outright. 200k matches the
+  # smallest window OrcaRouter publishes for its own routes, and sessions here
+  # reset after a day idle and are per-user, so they rarely approach it. Raise
+  # it once the route's real floor is known.
+  context_length: 200000
 
 # Allow-list of what the agent may call. `web` is web_search plus web_extract:
 # search alone returns titles, URLs and snippets, which is not enough to answer


### PR DESCRIPTION
Replaces `deepseek/deepseek-v4-flash-free` with `orcarouter/meai`.

## On verifying it exists

`meai` is account-scoped, so OrcaRouter's public `/v1/models` does not list it — the unauthenticated catalogue returns 196 models and none of them match. Confirmed instead from inside the running container, using the credential already in its environment:

```
AUTHED total: 10
orcarouter/meai present: True
  orcarouter/meai         ctx=None
  orcarouter/m1sk9-router ctx=None
  orcarouter/auto         ctx=None
  orcarouter/fusion       ctx=1000000
  ...
```

Ten models on this account, against 196 in public. Worth recording, because "not in the catalogue" is not evidence of absence here and the next person to check will otherwise reach the wrong conclusion.

## `context_length` drops to 200000

The route reports a null window, so auto-detection has nothing to read and the value has to be stated — same situation as the `-free` variants.

Choosing it low is deliberate. The two errors are not symmetric:

- **Too small** — Hermes compresses earlier than it had to. Mild waste.
- **Too large** — Hermes assembles a request the upstream rejects. Hard failure.

A route can also change what answers it without anything in this repo changing, so the number has to hold for the smallest model it might land on, not the largest. 200k is the floor OrcaRouter publishes across its own routes.

The practical cost is close to zero: sessions here are per-user and reset after a day idle, so they rarely approach 200k.

**Raise it if you know `meai`'s real floor** — it is one line, and you know what the route fans out to.

Generated with Claude Code