### PR TITLE
Pin Hermes' context window to what the meai route can actually serve

### DIFF
--- a/ansible/roles/docker_compose_app/files/hermes/config.yaml
+++ b/ansible/roles/docker_compose_app/files/hermes/config.yaml
@@ -18,13 +18,16 @@ model:
   # model, what actually answers can change without anything here changing.
   default: "orcarouter/meai"
   # The listing reports a null context_length for this route, so auto-detection
-  # has nothing to read. Pinned low on purpose: the two errors are not
-  # symmetric. Too small only compresses earlier than it had to; too large lets
-  # Hermes build a request the upstream then rejects outright. 200k matches the
-  # smallest window OrcaRouter publishes for its own routes, and sessions here
-  # reset after a day idle and are per-user, so they rarely approach it. Raise
-  # it once the route's real floor is known.
-  context_length: 200000
+  # has nothing to read and the value has to be stated. It must hold for the
+  # smallest model the route can land on, not the largest: too small only
+  # compresses earlier than it had to, while too large lets Hermes build a
+  # request the upstream rejects outright.
+  #
+  # meai fans out across qwen3.6-flash (1048576), qwen3.7-flash (1000000),
+  # deepseek-v4-flash-free (unreported) and qwen3.8-27b-free — and that last
+  # one is 65536. Anything above it breaks every turn the router happens to
+  # send there. Revisit when the route's membership changes.
+  context_length: 65536
 
 # Allow-list of what the agent may call. `web` is web_search plus web_extract:
 # search alone returns titles, URLs and snippets, which is not enough to answer


### PR DESCRIPTION
`200000` was picked in #371 as a conservative guess for `orcarouter/meai`, whose listing reports a null window. It was not conservative enough.

## What the route actually contains

`meai` fans out across four models:

| Model | Context |
|---|---|
| `qwen/qwen3.6-flash` | 1 048 576 |
| `qwen/qwen3.7-flash` | 1 000 000 |
| `deepseek/deepseek-v4-flash-free` | unreported |
| **`qwen/qwen3.8-27b-free`** | **65 536** |

A route's context length has to hold for the smallest model it can land on, not the largest. At `200000`, any session past 64k would be rejected on whichever turns the router happened to send to `qwen3.8-27b-free` — intermittently, with no pattern the logs would explain, and only after a conversation had run long enough to get there. Three of the four being an order of magnitude larger is precisely what makes this ceiling invisible until it trips.

## Cost of the fix

Close to nothing. Hermes compresses earlier than it strictly must on the turns that land on a large model. Sessions here are per-user and reset after a day idle, so few will approach even 64k.

Revisit if the route's membership changes — nothing in this repo can detect that, since the listing reports null.

Generated with Claude Code