### PR TITLE
Refuse Discord DMs while leaving server channels open

### DIFF
--- a/ansible/roles/docker_compose_app/files/hermes/compose.yaml
+++ b/ansible/roles/docker_compose_app/files/hermes/compose.yaml
@@ -9,13 +9,19 @@ services:
       # gateway cannot write config.yaml, state.db, or sessions.
       PUID: "1000"
       PGID: "1000"
-      # Open to anyone who can see the bot, against the fail-closed default.
-      # Deliberate: this is a chat assistant in a small guild. It sits here
-      # rather than in the vault-encrypted env file because "the door is open"
-      # is a fact a reviewer should read in the diff, not one buried in a blob.
-      # Slash commands stay gated separately — see gateway.platforms.discord
-      # in config.yaml.
-      DISCORD_ALLOW_ALL_USERS: "true"
+      # Open to anyone who can see the bot, against the fail-closed default,
+      # but in server channels only. The wildcard is what draws that line:
+      # Hermes consults the channel allow-list solely when `not is_dm`, so a
+      # DM matches nothing and is refused, while every guild channel matches.
+      # DISCORD_ALLOW_ALL_USERS would open both at once, and a user allow-list
+      # cannot be combined with this — configuring one disables the
+      # channel-based path entirely.
+      #
+      # It sits here rather than in the vault-encrypted env file because "the
+      # door is open" is a fact a reviewer should read in the diff, not one
+      # buried in a blob. Slash commands stay gated separately — see
+      # gateway.platforms.discord in config.yaml.
+      DISCORD_ALLOWED_CHANNELS: "*"
     volumes:
       - /home/m1sk9/hermes-data:/opt/data
     env_file:


### PR DESCRIPTION
`DISCORD_ALLOW_ALL_USERS` opened both surfaces at once. `require_mention` does not narrow that — it governs server channels only, and **DMs answer every message regardless of it**. So anyone able to find the bot could hold a private session with it: on a shared free-tier quota, unseen by anyone else in the guild.

## Where the line actually gets drawn

Not where the allow-list is written, but where it is consulted. From the running image, `plugins/platforms/discord/adapter.py`:

```python
if not has_users and not has_roles:
    if self._discord_allow_all_users(): return True
    # Channel-scoped guild access requires validated channel context.
    if (not is_dm
        and channel_ids is not None
        and self._discord_channel_ids_allowed(channel_ids)): return True
    return False
```

and

```python
def _discord_channel_ids_allowed(self, channel_ids):
    ...
    if "*" in allowed: return True
```

The channel path is gated on `not is_dm`, and the wildcard is honoured. A wildcard channel list therefore admits every guild channel and no DM — exactly the split wanted, with no channel IDs to enumerate or keep current.

Neither the wildcard nor the `is_dm` gate is documented; both were read out of the image.

## Resulting behaviour

| | Server channels | DMs |
|---|---|---|
| Before | everyone, on `@mention` | **everyone, every message** |
| After | everyone, on `@mention` | refused |

## What this cannot express

Naming any user or role makes `has_users` true and skips the branch entirely. "Open to the guild, but only I may DM" has no configuration — open channels and a DM allow-list are mutually exclusive. Worth recording so the next attempt does not go looking for it.

One path still bypasses this: `_is_pairing_approved_user` returns early and ignores `is_dm`. No pairing grants exist on this install (`hermes pairing` is how they are issued), so nothing is affected today.

Generated with Claude Code