### PR TITLE
Restore Discord access, which #374 took away entirely

### DIFF
--- a/ansible/roles/docker_compose_app/files/hermes/compose.yaml
+++ b/ansible/roles/docker_compose_app/files/hermes/compose.yaml
@@ -9,19 +9,21 @@ services:
       # gateway cannot write config.yaml, state.db, or sessions.
       PUID: "1000"
       PGID: "1000"
-      # Open to anyone who can see the bot, against the fail-closed default,
-      # but in server channels only. The wildcard is what draws that line:
-      # Hermes consults the channel allow-list solely when `not is_dm`, so a
-      # DM matches nothing and is refused, while every guild channel matches.
-      # DISCORD_ALLOW_ALL_USERS would open both at once, and a user allow-list
-      # cannot be combined with this — configuring one disables the
-      # channel-based path entirely.
+      # Open to anyone who can see the bot, against the fail-closed default.
+      #
+      # Not DISCORD_ALLOWED_CHANNELS: that gates the Discord adapter but never
+      # authorizes anyone at the gateway above it. That layer refuses to read an
+      # adapter's "open" policy as authorization at all — SECURITY.md 2.6
+      # requires an allowlist for every network-exposed adapter, and trusting
+      # "open" was a fail-open bug (#34515). A channel list is not a sender
+      # list, so every message fell through to default-deny. This flag is one of
+      # the explicit opt-ins that layer does honour.
       #
       # It sits here rather than in the vault-encrypted env file because "the
       # door is open" is a fact a reviewer should read in the diff, not one
       # buried in a blob. Slash commands stay gated separately — see
       # gateway.platforms.discord in config.yaml.
-      DISCORD_ALLOWED_CHANNELS: "*"
+      DISCORD_ALLOW_ALL_USERS: "true"
     volumes:
       - /home/m1sk9/hermes-data:/opt/data
     env_file:


### PR DESCRIPTION
**The bot is currently denying every message.** #374 is the cause and this reverts its mechanism.

```
2026-08-23 12:57:32 WARNING gateway.run: Unauthorized user: 586824421470109716 (...) on discord
2026-08-23 12:58:12 WARNING gateway.run: Unauthorized user: 586824421470109716 (...) on discord
```

## What I got wrong

#374 swapped `DISCORD_ALLOW_ALL_USERS` for `DISCORD_ALLOWED_CHANNELS="*"`, on the strength of the Discord adapter's `_is_allowed_user` — which does consult the channel list only when `not is_dm`, exactly as that PR described. The reasoning was sound about the function and wrong about the system: **the adapter is not the only gate.**

`gateway/authz_mixin.py` sits above it and refuses, by design, to read a permissive adapter as authorization:

```python
# The adapters default dm_policy / group_policy to "open", which forwards
# EVERY sender. Reading "reached the gateway" as authorization in that case
# would admit the whole external network with no operator-configured
# allowlist -- the fail-open SECURITY.md 2.6 forbids ...
# (#34515 follow-up: trusting "open" was a fail-open.)
if effective_policy == "allowlist":
```

A channel list is not a sender list. Nothing about `DISCORD_ALLOWED_CHANNELS` raises the effective policy to `"allowlist"`, so every message — DM and channel alike — fell through to default-deny. `DISCORD_ALLOW_ALL_USERS` is checked earlier, as one of the explicit opt-ins that layer honours, which is why this worked before #374.

I should have traced the authorization path end to end before claiming the split worked, rather than stopping at the first function that looked decisive.

## Scope

Restores pre-#374 behaviour exactly: channels open, **DMs open again**. That is a regression against what you asked for, and it is deliberate here — the outage should be fixed with the change known to work, not with a second untested theory.

## The DM restriction, done properly

`DISCORD_ALLOWED_ROLES` looks like the real answer, and unlike the channel list it is honoured at both layers:

```python
# Adapter-verified role auth: the Discord adapter already confirmed the
# user holds a role in DISCORD_ALLOWED_ROLES before dispatching the message.
if allow_adapter_delegation and getattr(source, "role_authorized", False) is True:
    return True
```

and the adapter refuses role auth in DMs unless `discord.dm_role_auth_guild` is set — the cross-guild-leakage guard. Roles authorize channels; DMs stay shut.

Two things to settle before that ships, neither suited to an outage fix:

1. Setting `DISCORD_ALLOWED_ROLES` **auto-enables the Server Members Intent**, which must be enabled in the Developer Portal first or the gateway fails to connect with `PrivilegedIntentsRequired`.
2. Whether `@everyone` (role id = guild id) satisfies the check, which decides if this means "the whole guild" or "a role you grant".

Generated with Claude Code