### PR TITLE
Gate Discord access on a role, restoring service and closing DMs

### DIFF
--- a/ansible/roles/docker_compose_app/files/hermes/compose.yaml
+++ b/ansible/roles/docker_compose_app/files/hermes/compose.yaml
@@ -9,19 +9,26 @@ services:
       # gateway cannot write config.yaml, state.db, or sessions.
       PUID: "1000"
       PGID: "1000"
-      # Open to anyone who can see the bot, against the fail-closed default,
-      # but in server channels only. The wildcard is what draws that line:
-      # Hermes consults the channel allow-list solely when `not is_dm`, so a
-      # DM matches nothing and is refused, while every guild channel matches.
-      # DISCORD_ALLOW_ALL_USERS would open both at once, and a user allow-list
-      # cannot be combined with this — configuring one disables the
-      # channel-based path entirely.
+      # Access is a granted Discord role, which is the one lever that opens
+      # server channels without also opening DMs.
       #
-      # It sits here rather than in the vault-encrypted env file because "the
-      # door is open" is a fact a reviewer should read in the diff, not one
-      # buried in a blob. Slash commands stay gated separately — see
-      # gateway.platforms.discord in config.yaml.
-      DISCORD_ALLOWED_CHANNELS: "*"
+      # Both layers have to agree, and only this one satisfies both. The gateway
+      # refuses to read an adapter's permissive intake as authorization at all
+      # (SECURITY.md 2.6; trusting "open" was the fail-open of #34515), so
+      # DISCORD_ALLOWED_CHANNELS authorized nobody and denied every message.
+      # Roles are different — the adapter verifies the role against the message's
+      # own guild and sets source.role_authorized, which the gateway honours.
+      #
+      # DMs are refused by construction: the adapter's DM branch demands
+      # discord.dm_role_auth_guild before it will consider a role at all, and
+      # that key is deliberately unset. Leave it that way — it exists to stop a
+      # role held in any mutual guild from authorizing a DM.
+      #
+      # Requires the Server Members Intent (auto-enabled on connect once this is
+      # set); without it in the Developer Portal the gateway will not connect.
+      # It sits here rather than in the vault-encrypted env file because who may
+      # reach the bot is a fact a reviewer should read in the diff.
+      DISCORD_ALLOWED_ROLES: "1521203591954829384"
     volumes:
       - /home/m1sk9/hermes-data:/opt/data
     env_file:

--- a/ansible/roles/docker_compose_app/files/hermes/config.yaml
+++ b/ansible/roles/docker_compose_app/files/hermes/config.yaml
@@ -138,4 +138,7 @@ discord:
   # sessions this bot holds are per-user already (group_sessions_per_user
   # defaults to true), so the isolation is redundant here.
   auto_thread: false
-  reactions: true
+  # No 👀/✅/❌ on the messages it processes. With auto_thread off the bot already
+  # replies inline, so the reply is the acknowledgement and the reactions only
+  # mark up other people's messages in a shared channel.
+  reactions: false


### PR DESCRIPTION
**The bot is currently denying every message**, including from the operator. #374 is the cause. This fixes it and gets the DM restriction it was aiming for, in one deploy. Supersedes #376, which would have restored service by reopening DMs.

```
2026-08-23 12:57:32 WARNING gateway.run: Unauthorized user: 586824421470109716 (...) on discord
```

## Why the channel wildcard authorized nobody

#374 read the Discord adapter's `_is_allowed_user` and stopped there. The reasoning was right about that function and wrong about the system: the adapter is not the only gate. `gateway/authz_mixin.py` sits above it and refuses, deliberately, to read a permissive adapter as authorization:

```python
# The adapters default dm_policy / group_policy to "open", which forwards
# EVERY sender. Reading "reached the gateway" as authorization in that case
# would admit the whole external network with no operator-configured
# allowlist -- the fail-open SECURITY.md 2.6 forbids ...
if effective_policy == "allowlist":
```

A channel list is not a sender list, so nothing raised the policy to `"allowlist"` and every message fell through to default-deny.

## Why a role clears both layers

**Adapter** — resolves the member in the message's *own* guild (never other mutual guilds, the cross-guild bypass it guards against), then:

```python
role_authorized = bool(getattr(self, "_allowed_role_ids", set()))
```

**Gateway** — honours that flag directly, ahead of the default-deny:

```python
# Adapter-verified role auth: the Discord adapter already confirmed the
# user holds a role in DISCORD_ALLOWED_ROLES before dispatching the message.
if allow_adapter_delegation and getattr(source, "role_authorized", False) is True:
    return True
```

## Why DMs stay shut

Nothing had to be configured to shut them. The adapter's DM branch demands an opt-in that is absent:

```python
if is_dm or guild is None:
    dm_guild_id = _read_dm_role_auth_guild()
    if dm_guild_id is None:
        return False
```

`discord.dm_role_auth_guild` is deliberately not set — it exists so a role held in *some other* shared guild cannot authorize a DM. The refusal is structural rather than configured, which is a stronger guarantee than #374's was.

| | Server channels | DMs |
|---|---|---|
| Before #374 | everyone, on `@mention` | everyone |
| After #374 (now) | **nobody** | nobody |
| After this | holders of the role, on `@mention` | refused |

Access is now a granted role rather than the whole guild — narrower than before, and revocable per person without a deploy.

## Prerequisite

Setting `DISCORD_ALLOWED_ROLES` auto-enables the **Server Members Intent** on connect. It must be enabled in the Developer Portal, or the gateway fails to start with `PrivilegedIntentsRequired` — a harder failure than the current one. Confirmed as handled before opening this.

## Also: reactions off

`auto_thread` is already off, so replies land inline and the reply is itself the acknowledgement. The 👀/✅/❌ marks were adding emoji to other people's messages in a shared channel to say what the answer says a moment later.

Generated with Claude Code